### PR TITLE
Fix model info readiness check and trim text content

### DIFF
--- a/src/proxy_app/main.py
+++ b/src/proxy_app/main.py
@@ -951,7 +951,7 @@ async def list_models(
     
     if enriched and hasattr(request.app.state, 'model_info_service'):
         model_info_service = request.app.state.model_info_service
-        if model_info_service.is_ready():
+        if model_info_service.is_ready:
             # Return enriched model data
             enriched_data = model_info_service.enrich_model_list(model_ids)
             return {"object": "list", "data": enriched_data}

--- a/src/rotator_library/providers/antigravity_provider.py
+++ b/src/rotator_library/providers/antigravity_provider.py
@@ -1012,14 +1012,14 @@ class AntigravityProvider(AntigravityAuthBase, ProviderInterface):
         parts = []
         
         if isinstance(content, str):
-            if content:
-                parts.append({"text": content})
+            if content.strip():
+                parts.append({"text": content.strip()})
         elif isinstance(content, list):
             for item in content:
                 if item.get("type") == "text":
                     text = item.get("text", "")
-                    if text:
-                        parts.append({"text": text})
+                    if text.strip():
+                        parts.append({"text": text.strip()})
                 elif item.get("type") == "image_url":
                     image_part = self._parse_image_url(item.get("image_url", {}))
                     if image_part:


### PR DESCRIPTION
Replaces method call with property access for model_info_service readiness check in main.py. Also ensures text content is stripped of whitespace before appending in AntigravityProvider, improving data consistency.

Basically just some bug fixes for minor issues I had getting the proxy to serve Antigravity generally and to produce more than "Thinking" messages
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix readiness check in `main.py` and trim text content in `antigravity_provider.py` for improved data consistency.
> 
>   - **Behavior**:
>     - Replace method call `is_ready()` with property access `is_ready` for `model_info_service` readiness check in `main.py`.
>     - Ensure text content is stripped of whitespace before appending in `AntigravityProvider` in `antigravity_provider.py`.
>   - **Misc**:
>     - Minor bug fixes to improve proxy serving and message generation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Mirrowel%2FLLM-API-Key-Proxy&utm_source=github&utm_medium=referral)<sup> for bf2439b0c9fea1443c2c663bfa8268c3daca0cae. You can [customize](https://app.ellipsis.dev/Mirrowel/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->