### PR TITLE
fix(quota): recognize env:// credential format in quota stats

### DIFF
--- a/src/rotator_library/usage_manager.py
+++ b/src/rotator_library/usage_manager.py
@@ -184,6 +184,7 @@ class UsageManager:
         Extract provider name from credential path or identifier.
 
         Supports multiple credential formats:
+        - Env-based OAuth: "env://antigravity/1" -> "antigravity"
         - OAuth: "oauth_creds/antigravity_oauth_15.json" -> "antigravity"
         - OAuth: "C:\\...\\oauth_creds\\gemini_cli_oauth_1.json" -> "gemini_cli"
         - OAuth filename only: "antigravity_oauth_1.json" -> "antigravity"
@@ -196,6 +197,13 @@ class UsageManager:
             Provider name string or None if cannot be determined
         """
         import re
+
+        # Pattern: env-based OAuth credentials "env://provider/index"
+        if credential.startswith("env://"):
+            # Extract provider from env://provider/index format
+            match = re.match(r"env://([a-z_]+)/\d+$", credential, re.IGNORECASE)
+            if match:
+                return match.group(1).lower()
 
         # Normalize path separators
         normalized = credential.replace("\\", "/")


### PR DESCRIPTION
## 📝 Summary

Fixes quota stats returning empty results (`total_credentials: 0`) on stateless deployments (e.g., Render) where credentials are loaded from environment variables using the `env://provider/index` format.

## 🐛 Problem

The hosted proxy on Render was returning empty quota stats while the local instance showed proper values:

| Environment | `total_credentials` | `providers` |
|-------------|---------------------|-------------|
| Render (before fix) | `0` | `[]` |
| Local | `13` | `['antigravity', 'gemini_cli', ...]` |

Both were running the same branch, but Render uses environment variable-based OAuth credentials.

## 🔍 Root Cause

The `_get_provider_from_credential()` function in `UsageManager` did not recognize the `env://provider/index` credential format. It only matched these patterns:

- `/([a-z_]+)_oauth_\d+\.json$` — path ending with `{provider}_oauth_{number}.json`
- `oauth_creds/([a-z_]+)_` — path containing `oauth_creds/{provider}_`
- `([a-z_]+)_oauth_\d+\.json$` — filename only `{provider}_oauth_{number}.json`

But it did **NOT** handle `env://antigravity/1`, `env://gemini_cli/1`, etc., causing all env-based credentials to be silently skipped when building quota stats.

## ✨ The Fix

Added pattern matching for `env://` URIs at the start of the function:

```python
# Pattern: env-based OAuth credentials "env://provider/index"
if credential.startswith("env://"):
    # Extract provider from env://provider/index format
    match = re.match(r"env://([a-z_]+)/\d+$", credential, re.IGNORECASE)
    if match:
        return match.group(1).lower()
```

## 📁 Files Changed

| File | Change Type | Impact |
|------|-------------|--------|
| `src/rotator_library/usage_manager.py` | 🔧 Modified | +8 lines — adds env:// pattern matching |

## 🧪 Testing & Verification

1. **Unit tested** the regex pattern with all credential formats
2. **Deployed to Render** and verified via `/v1/quota-stats` endpoint
3. All 12 Antigravity env-based credentials now properly recognized

### Before/After Comparison

| Metric | Before | After |
|--------|--------|-------|
| `total_credentials` | `0` | `12` |
| `providers` | `[]` | `['antigravity']` |
| `total_requests` | `0` | `6755` |

## 📋 Checklist

- [x] Code follows project conventions
- [x] Tested on production deployment (Render)
- [x] No breaking changes
- [x] Backwards compatible with file-based credentials

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `UsageManager` to recognize `env://provider/index` credential format in `usage_manager.py`.
> 
>   - **Behavior**:
>     - Fixes `UsageManager` to recognize `env://provider/index` credential format in `_get_provider_from_credential()`.
>     - Handles credentials like `env://antigravity/1`, `env://gemini_cli/1`.
>   - **Files**:
>     - `usage_manager.py`: Adds regex pattern for `env://` format in `_get_provider_from_credential()`.
>   - **Testing**:
>     - Verified on Render deployment with `/v1/quota-stats` endpoint.
>     - Unit tests for regex pattern with all credential formats.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Mirrowel%2FLLM-API-Key-Proxy&utm_source=github&utm_medium=referral)<sup> for 05c37c1ecf0701659963fc720ca1e802346de13d. You can [customize](https://app.ellipsis.dev/Mirrowel/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->