### PR TITLE
fix(usage_manager): 🐛 prevent stale API responses from resetting quota count (#75)

### DIFF
--- a/src/rotator_library/usage_manager.py
+++ b/src/rotator_library/usage_manager.py
@@ -3244,8 +3244,13 @@ class UsageManager:
                     max_requests = model_data.get("quota_max_requests")
 
             # Sync local request count to API's authoritative value
-            model_data["request_count"] = used_requests
-            model_data["requests_at_baseline"] = used_requests
+            # Use max() to prevent API from resetting our count if it returns stale/cached 100%
+            # The API can only increase our count (if we missed requests), not decrease it
+            # See: https://github.com/Mirrowel/LLM-API-Key-Proxy/issues/75
+            current_count = model_data.get("request_count", 0)
+            synced_count = max(current_count, used_requests)
+            model_data["request_count"] = synced_count
+            model_data["requests_at_baseline"] = synced_count
 
             # Update baseline fields
             model_data["baseline_remaining_fraction"] = remaining_fraction
@@ -3254,7 +3259,7 @@ class UsageManager:
             # Update max_requests and quota_display
             if max_requests is not None:
                 model_data["quota_max_requests"] = max_requests
-                model_data["quota_display"] = f"{used_requests}/{max_requests}"
+                model_data["quota_display"] = f"{synced_count}/{max_requests}"
 
             # Handle reset_timestamp: only trust it when quota has been used (< 100%)
             # API returns garbage reset times for unused quota
@@ -3339,19 +3344,19 @@ class UsageManager:
                                 "approx_cost": 0.0,
                             },
                         )
-                        # Sync request tracking
-                        other_model_data["request_count"] = used_requests
+                        # Sync request tracking (use synced_count to prevent reset bug)
+                        other_model_data["request_count"] = synced_count
                         if max_requests is not None:
                             other_model_data["quota_max_requests"] = max_requests
                             other_model_data["quota_display"] = (
-                                f"{used_requests}/{max_requests}"
+                                f"{synced_count}/{max_requests}"
                             )
                         # Sync baseline fields
                         other_model_data["baseline_remaining_fraction"] = (
                             remaining_fraction
                         )
                         other_model_data["baseline_fetched_at"] = now_ts
-                        other_model_data["requests_at_baseline"] = used_requests
+                        other_model_data["requests_at_baseline"] = synced_count
                         # Sync reset timestamp if valid
                         if valid_reset_ts:
                             other_model_data["quota_reset_ts"] = reset_timestamp
@@ -3381,7 +3386,7 @@ class UsageManager:
 
             lib_logger.debug(
                 f"Updated quota baseline for {mask_credential(credential)} model={model}: "
-                f"remaining={remaining_fraction:.2%}, synced_request_count={used_requests}"
+                f"remaining={remaining_fraction:.2%}, synced_request_count={synced_count}"
             )
 
         await self._save_usage()


### PR DESCRIPTION
## Summary

- Prevents stale API responses (returning `remainingFraction: 1.0`) from resetting local quota tracking to 0
- Uses `max(current_count, used_requests)` to ensure the API can only increase our count, never decrease it
- Applied fix to both primary model and grouped models to maintain state consistency

## Problem

When background refresh syncs with the API and receives a cached/stale response showing 100% remaining, the calculated `used_requests` becomes 0. The previous code unconditionally overwrote local tracking with this value, wiping out accurate request counts.

## Solution

The API can only increase our count (if we missed requests), never decrease it. This prevents stale cache responses from corrupting local state while still allowing the API to correct our count upward if needed.

Fixes #75
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes stale API responses resetting quota count to 0 in `update_quota_baseline()` by using `max()` to ensure the count only increases.
> 
>   - **Behavior**:
>     - Fixes stale API responses resetting quota count to 0 in `update_quota_baseline()` in `usage_manager.py`.
>     - Uses `max(current_count, used_requests)` to ensure API can only increase count, not decrease it.
>     - Applies fix to both primary and grouped models for consistency.
>   - **Misc**:
>     - Updates `quota_display` to use `synced_count` instead of `used_requests`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Mirrowel%2FLLM-API-Key-Proxy&utm_source=github&utm_medium=referral)<sup> for f663c457108dc304b630c4c982974c74a978be60. You can [customize](https://app.ellipsis.dev/Mirrowel/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->