### PR TITLE
feat(quota): ✨ implement authoritative local counting and retry tracking

### DIFF
--- a/src/rotator_library/client.py
+++ b/src/rotator_library/client.py
@@ -1495,6 +1495,14 @@ class RotatingClient:
                                             f"Pre-request callback failed but abort_on_callback_error is False. Proceeding with request. Error: {e}"
                                         )
 
+                            # Add retry callback to track additional requests (bare 429s, empty responses)
+                            async def on_retry_attempt(m: str) -> None:
+                                await self.usage_manager.increment_request_count(
+                                    current_cred, m
+                                )
+
+                            litellm_kwargs["on_retry_attempt"] = on_retry_attempt
+
                             response = await provider_plugin.acompletion(
                                 self.http_client, **litellm_kwargs
                             )
@@ -2267,6 +2275,14 @@ class RotatingClient:
                                             lib_logger.warning(
                                                 f"Pre-request callback failed but abort_on_callback_error is False. Proceeding with request. Error: {e}"
                                             )
+
+                                # Add retry callback to track additional requests (bare 429s, empty responses)
+                                async def on_retry_attempt(m: str) -> None:
+                                    await self.usage_manager.increment_request_count(
+                                        current_cred, m
+                                    )
+
+                                litellm_kwargs["on_retry_attempt"] = on_retry_attempt
 
                                 response = await provider_plugin.acompletion(
                                     self.http_client, **litellm_kwargs

--- a/src/rotator_library/providers/utilities/antigravity_quota_tracker.py
+++ b/src/rotator_library/providers/utilities/antigravity_quota_tracker.py
@@ -987,6 +987,7 @@ class AntigravityQuotaTracker(BaseQuotaTracker):
         self,
         quota_results: Dict[str, Dict[str, Any]],
         usage_manager: "UsageManager",
+        sync_mode: str = "force",
     ) -> int:
         """
         Store fetched quota baselines into UsageManager.
@@ -994,6 +995,7 @@ class AntigravityQuotaTracker(BaseQuotaTracker):
         Args:
             quota_results: Dict from fetch_quota_from_api or fetch_initial_baselines
             usage_manager: UsageManager instance to store baselines in
+            sync_mode: How to sync request_count ("force", "if_exhausted", "none")
 
         Returns:
             Number of baselines successfully stored
@@ -1052,7 +1054,12 @@ class AntigravityQuotaTracker(BaseQuotaTracker):
                 # Store with provider prefix for consistency with usage tracking
                 prefixed_model = f"antigravity/{user_model}"
                 cooldown_info = await usage_manager.update_quota_baseline(
-                    cred_path, prefixed_model, remaining, max_requests, reset_timestamp
+                    cred_path,
+                    prefixed_model,
+                    remaining,
+                    max_requests,
+                    reset_timestamp,
+                    sync_mode=sync_mode,
                 )
 
                 # Aggregate cooldown info if returned

--- a/src/rotator_library/providers/utilities/base_quota_tracker.py
+++ b/src/rotator_library/providers/utilities/base_quota_tracker.py
@@ -507,6 +507,7 @@ class BaseQuotaTracker:
         self,
         quota_results: Dict[str, Dict[str, Any]],
         usage_manager: "UsageManager",
+        sync_mode: str = "force",
     ) -> int:
         """
         Store fetched quota baselines into UsageManager.
@@ -514,6 +515,7 @@ class BaseQuotaTracker:
         Args:
             quota_results: Dict from _fetch_quota_for_credential or fetch_initial_baselines
             usage_manager: UsageManager instance to store baselines in
+            sync_mode: How to sync request_count ("force", "if_exhausted", "none")
 
         Returns:
             Number of baselines successfully stored
@@ -541,7 +543,11 @@ class BaseQuotaTracker:
 
                 # Store baseline
                 await usage_manager.update_quota_baseline(
-                    cred_path, prefixed_model, remaining, max_requests=max_requests
+                    cred_path,
+                    prefixed_model,
+                    remaining,
+                    max_requests=max_requests,
+                    sync_mode=sync_mode,
                 )
                 stored_count += 1
 

--- a/src/rotator_library/usage_manager.py
+++ b/src/rotator_library/usage_manager.py
@@ -3228,6 +3228,11 @@ class UsageManager:
             }
         """
         await self._lazy_init()
+        if sync_mode not in ("force", "if_exhausted", "none"):
+            lib_logger.warning(
+                f"Unknown sync_mode '{sync_mode}', defaulting to 'force'"
+            )
+            sync_mode = "force"
         async with self._data_lock:
             now_ts = time.time()
 


### PR DESCRIPTION
Updates the usage tracking logic to handle providers where local counting is more accurate than API returns (specifically Antigravity).

- Implement `sync_mode` in `UsageManager` (`force`, `if_exhausted`, `none`) to control how API baselines affect local counters.
- Configure Antigravity credential manager to treat local counting as authoritative, skipping background refreshes to prevent valid usage data from being overwritten by stale API data.
- Add `on_retry_attempt` callback in `RotatingClient` and `AntigravityProvider` to track internal retries (bare 429s, empty responses) that consume quota.
- Introduce `measured_max_requests` tracking to dynamically learn the actual request limit of credentials.
Linked to #75 and #81 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Implement authoritative local counting and retry tracking for Antigravity provider with `sync_mode` and dynamic request limit learning.
> 
>   - **Behavior**:
>     - Implement `sync_mode` in `UsageManager` to control API baseline effects on local counters (`force`, `if_exhausted`, `none`).
>     - Antigravity treats local counting as authoritative, skipping background refreshes to avoid overwriting valid data with stale API data.
>     - Add `on_retry_attempt` callback in `RotatingClient` and `AntigravityProvider` to track retries (bare 429s, empty responses) that consume quota.
>     - Introduce `measured_max_requests` tracking to dynamically learn actual request limits.
>   - **Functions**:
>     - `increment_request_count()` in `UsageManager` to track retry attempts.
>     - `update_quota_baseline()` in `UsageManager` updated to handle `sync_mode` and measured max requests.
>   - **Misc**:
>     - Adjustments in `client.py` and `antigravity_provider.py` to integrate retry tracking and sync mode logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Mirrowel%2FLLM-API-Key-Proxy&utm_source=github&utm_medium=referral)<sup> for 2015eedf3aea22b8831a81ea4ddd8bb3646871c4. You can [customize](https://app.ellipsis.dev/Mirrowel/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->