### PR TITLE
fix(quota): add reset_time_iso to quota stats API response

### DIFF
--- a/src/rotator_library/usage_manager.py
+++ b/src/rotator_library/usage_manager.py
@@ -1211,6 +1211,23 @@ class UsageManager:
         except (OSError, ValueError, OverflowError):
             return None
 
+    def _format_timestamp_iso(self, ts: Optional[float]) -> Optional[str]:
+        """
+        Format Unix timestamp as ISO 8601 UTC string for API responses.
+
+        Args:
+            ts: Unix timestamp or None
+
+        Returns:
+            Formatted string like "2025-12-07T14:30:17Z" or None
+        """
+        if ts is None:
+            return None
+        try:
+            return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+        except (OSError, ValueError, OverflowError):
+            return None
+
     def _add_readable_timestamps(self, data: Dict) -> Dict:
         """
         Add human-readable timestamp fields to usage data before saving.
@@ -3723,6 +3740,9 @@ class UsageManager:
                             "approx_cost": model_stats.get("approx_cost", 0.0),
                             "window_start_ts": model_stats.get("window_start_ts"),
                             "quota_reset_ts": model_stats.get("quota_reset_ts"),
+                            "reset_time_iso": self._format_timestamp_iso(
+                                model_stats.get("quota_reset_ts")
+                            ),
                             # Quota baseline fields (Antigravity-specific)
                             "baseline_remaining_fraction": model_stats.get(
                                 "baseline_remaining_fraction"


### PR DESCRIPTION
## Summary
- Adds `reset_time_iso` field to model stats in `/v1/quota-stats` API response
- Provides human-readable ISO 8601 UTC timestamp for quota reset time
- Fixes issue where end users only received Unix timestamp without readable format

## Changes
- **src/rotator_library/usage_manager.py**
  - Added `_format_timestamp_iso()` method to format Unix timestamps as ISO 8601 UTC strings
  - Added `reset_time_iso` field to model stats dict in `get_stats_for_endpoint()`

## Context
Previously, the `/v1/quota-stats` endpoint returned only `quota_reset_ts` (Unix timestamp). Now it also returns `reset_time_iso` (ISO 8601 UTC string) following the established `_iso` suffix pattern.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `reset_time_iso` to `/v1/quota-stats` API response for ISO 8601 UTC timestamp of quota reset time.
> 
>   - **Behavior**:
>     - Adds `reset_time_iso` field to `/v1/quota-stats` API response, providing ISO 8601 UTC timestamp for quota reset time.
>     - Previously, only `quota_reset_ts` (Unix timestamp) was returned.
>   - **Functions**:
>     - Adds `_format_timestamp_iso()` in `usage_manager.py` to convert Unix timestamps to ISO 8601 UTC strings.
>     - Updates `get_stats_for_endpoint()` in `usage_manager.py` to include `reset_time_iso` in model stats.
>   - **Context**:
>     - Follows `_iso` suffix pattern for human-readable timestamps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Mirrowel%2FLLM-API-Key-Proxy&utm_source=github&utm_medium=referral)<sup> for 96d8d01c71422f904aaeae7e561e8cb6579c386c. You can [customize](https://app.ellipsis.dev/Mirrowel/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->