### PR TITLE
feat(embeddings): fix embedding dispatch in executor

### DIFF
--- a/src/rotator_library/core/types.py
+++ b/src/rotator_library/core/types.py
@@ -63,6 +63,7 @@ class RequestContext:
     streaming: bool
     credentials: List[str]
     deadline: float
+    request_type: Literal["completion", "embedding"] = "completion"
     request: Optional[Any] = None  # FastAPI Request object
     pre_request_callback: Optional[Callable] = None
     transaction_logger: Optional[Any] = None


### PR DESCRIPTION
The embedding endpoint existed but was broken because the executor refactoring (Nov 2025) forgot to add litellm.aembedding() dispatch. All requests were going through litellm.acompletion(), causing failures.

Changes:
- Add request_type field to RequestContext (completion/embedding)
- Update RotatingClient.aembedding() to set request_type='embedding'
- Add conditional dispatch in RequestExecutor._execute_non_streaming() to call litellm.aembedding() for embedding requests
- Refactored dispatch logic to reduce code duplication

Tested with Mistral (mistral-embed) - returns proper 1024-dim vectors.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix embedding dispatch in `RequestExecutor` by adding `request_type` to `RequestContext` and updating logic to correctly handle embedding requests.
> 
>   - **Behavior**:
>     - Fix embedding dispatch in `RequestExecutor._execute_non_streaming()` to call `litellm.aembedding()` for embedding requests.
>     - Add `request_type` field to `RequestContext` in `types.py` to distinguish between completion and embedding requests.
>     - Update `RotatingClient.aembedding()` to set `request_type='embedding'`.
>   - **Testing**:
>     - Tested with Mistral (mistral-embed) to ensure correct 1024-dim vector results.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Mirrowel%2FLLM-API-Key-Proxy&utm_source=github&utm_medium=referral)<sup> for 2c755e80de6882edbd722909daf5c4516541c2a0. You can [customize](https://app.ellipsis.dev/Mirrowel/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->