### PR TITLE
fix(iflow): add signed headers for chat requests

### DIFF
--- a/src/rotator_library/providers/iflow_auth_base.py
+++ b/src/rotator_library/providers/iflow_auth_base.py
@@ -622,7 +622,7 @@ class IFlowAuthBase:
         if not result.get("success"):
             raise ValueError("iFlow user info request not successful")
 
-        data = result.get("data", {})
+        data = result.get("data") or {}
         api_key = data.get("apiKey", "").strip()
         if not api_key:
             raise ValueError("Missing API key in user info response")
@@ -676,7 +676,7 @@ class IFlowAuthBase:
             error_msg = result.get("message", "Unknown error")
             raise ValueError(f"Cookie authentication failed: {error_msg}")
 
-        data = result.get("data", {})
+        data = result.get("data") or {}
 
         # Handle case where apiKey is masked - use apiKeyMask if apiKey is empty
         if not data.get("apiKey") and data.get("apiKeyMask"):
@@ -732,7 +732,7 @@ class IFlowAuthBase:
             error_msg = result.get("message", "Unknown error")
             raise ValueError(f"Cookie API key refresh failed: {error_msg}")
 
-        return result.get("data", {})
+        return result.get("data") or {}
 
     async def authenticate_with_cookie(self, cookie: str) -> Dict[str, Any]:
         """


### PR DESCRIPTION
## Summary
- Add iFlow signed headers (`session-id`, `x-iflow-timestamp`, `x-iflow-signature`) to match CLIProxyAPI request protocol.
- Build iFlow request headers via one helper and keep better context for empty upstream error bodies.
- Verified locally: the same iFlow credential now works and streams successfully in LLM-API-Key-Proxy curl tests.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add iFlow signed headers for chat requests and improve error handling in `iflow_provider.py`.
> 
>   - **Headers**:
>     - Add iFlow signed headers (`session-id`, `x-iflow-timestamp`, `x-iflow-signature`) in `iflow_provider.py` to match CLIProxyAPI protocol.
>     - Implement `_create_iflow_signature()` and `_build_iflow_headers()` to generate and include these headers.
>   - **Error Handling**:
>     - Improve handling of empty upstream error bodies in `stream_handler()` in `iflow_provider.py` by logging content-type.
>   - **Misc**:
>     - Change `result.get("data", {})` to `result.get("data") or {}` in `iflow_auth_base.py` to handle None values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Mirrowel%2FLLM-API-Key-Proxy&utm_source=github&utm_medium=referral)<sup> for 2265aa5d9c25384a41b1c37cb929165c49379b9e. You can [customize](https://app.ellipsis.dev/Mirrowel/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->