### PR TITLE
fix: initialize credentials before usage managers to resolve tier=None

### DIFF
--- a/src/rotator_library/background_refresher.py
+++ b/src/rotator_library/background_refresher.py
@@ -267,9 +267,10 @@ class BackgroundRefresher:
 
     async def _run(self):
         """The main loop for OAuth token refresh."""
-        await self._client.initialize_usage_managers()
-        # Initialize credentials (load persisted tiers) before starting
+        # Initialize credentials first to populate tier/project caches
         await self._initialize_credentials()
+        # Then initialize usage managers which reads from those caches
+        await self._client.initialize_usage_managers()
 
         # Start provider-specific background jobs with their own timers
         self._start_provider_background_jobs()


### PR DESCRIPTION
The _run() method was calling initialize_usage_managers() before _initialize_credentials(), so tier caches were empty when UsageManager read them. Swapping the order ensures project_tier_cache is populated before tiers are assigned to CredentialState objects.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> In `background_refresher.py`, `_run()` now initializes credentials before usage managers to ensure tier caches are populated, resolving an issue with empty tier caches.
> 
>   - **Behavior**:
>     - In `background_refresher.py`, `_run()` now calls `_initialize_credentials()` before `initialize_usage_managers()` to ensure tier caches are populated before usage managers read them.
>   - **Comments**:
>     - Updated comments in `_run()` to reflect the new order of initialization steps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Mirrowel%2FLLM-API-Key-Proxy&utm_source=github&utm_medium=referral)<sup> for daaf4d048ee7be6c77d47fe9375f092f1ccc8331. You can [customize](https://app.ellipsis.dev/Mirrowel/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->