### PR TITLE
fix(usage): derive API key last-used and bound stream memory

### DIFF
--- a/src/proxy_app/stream_usage.py
+++ b/src/proxy_app/stream_usage.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class StreamUsageTracker:
+    response_id: str | None = None
+    model: str | None = None
+    created: int | None = None
+    usage: dict[str, Any] | None = None
+
+    def ingest_chunk(self, chunk_data: dict[str, Any]) -> None:
+        if self.response_id is None:
+            response_id = chunk_data.get("id")
+            if isinstance(response_id, str):
+                self.response_id = response_id
+
+        if self.model is None:
+            model = chunk_data.get("model")
+            if isinstance(model, str):
+                self.model = model
+
+        if self.created is None:
+            created = chunk_data.get("created")
+            if isinstance(created, int):
+                self.created = created
+
+        usage = chunk_data.get("usage")
+        if isinstance(usage, dict) and usage:
+            self.usage = usage
+
+    def build_logging_payload(self) -> dict[str, Any]:
+        return {
+            "id": self.response_id,
+            "object": "chat.completion",
+            "created": self.created,
+            "model": self.model,
+            "choices": [],
+            "usage": self.usage,
+        }

--- a/src/proxy_app/templates/me.html
+++ b/src/proxy_app/templates/me.html
@@ -40,6 +40,7 @@
         <th>Name</th>
         <th>Prefix</th>
         <th>Created</th>
+        <th>Last used</th>
         <th>Status</th>
         <th>Action</th>
       </tr>
@@ -51,6 +52,7 @@
         <td>{{ key.name }}</td>
         <td><code>{{ key.token_prefix }}</code></td>
         <td>{{ key.created_at }}</td>
+        <td>{{ key.last_used_at if key.last_used_at else "-" }}</td>
         <td>{% if key.revoked_at %}Revoked{% else %}Active{% endif %}</td>
         <td>
           {% if not key.revoked_at %}
@@ -65,7 +67,7 @@
       </tr>
       {% else %}
       <tr>
-        <td colspan="6" class="muted">No API keys yet.</td>
+        <td colspan="7" class="muted">No API keys yet.</td>
       </tr>
       {% endfor %}
     </tbody>

--- a/tests/test_stream_usage.py
+++ b/tests/test_stream_usage.py
@@ -1,0 +1,36 @@
+from proxy_app.stream_usage import StreamUsageTracker
+
+
+def test_stream_usage_tracker_keeps_only_minimal_metadata() -> None:
+    tracker = StreamUsageTracker(model="openai/gpt-4o-mini")
+
+    for _ in range(5000):
+        tracker.ingest_chunk(
+            {
+                "id": "chatcmpl-123",
+                "model": "openai/gpt-4o-mini",
+                "created": 1700000000,
+                "choices": [
+                    {
+                        "delta": {
+                            "content": "x" * 200,
+                        }
+                    }
+                ],
+            }
+        )
+
+    tracker.ingest_chunk(
+        {
+            "id": "chatcmpl-123",
+            "model": "openai/gpt-4o-mini",
+            "usage": {"prompt_tokens": 12, "completion_tokens": 8, "total_tokens": 20},
+        }
+    )
+
+    payload = tracker.build_logging_payload()
+    assert payload["id"] == "chatcmpl-123"
+    assert payload["model"] == "openai/gpt-4o-mini"
+    assert payload["usage"]["total_tokens"] == 20
+    assert payload["choices"] == []
+    assert not hasattr(tracker, "response_chunks")


### PR DESCRIPTION
## Summary
- make `last_used_at` accurate in user/UI key listings by deriving from `MAX(usage_events.timestamp)` per key instead of relying on stale nullable column writes
- surface derived last-used timestamps in `/ui/me` API key table
- replace unbounded stream chunk accumulation with lightweight `StreamUsageTracker` metadata tracking for usage attribution and logging
- keep request accounting behavior unchanged while reducing stream memory growth risk

## Verification
- `PYTHONPATH=src .venv/bin/python -m py_compile src/proxy_app/usage_queries.py src/proxy_app/routers/user_api.py src/proxy_app/routers/ui.py src/proxy_app/stream_usage.py src/proxy_app/main.py tests/test_api_keys.py tests/test_stream_usage.py`
- `PYTHONPATH=src .venv/bin/pytest -q tests/test_api_keys.py tests/test_stream_usage.py tests/test_usage_attribution.py`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve API key last-used tracking and stream memory management with `StreamUsageTracker` and derived timestamps.
> 
>   - **Behavior**:
>     - Derive `last_used_at` for API keys from `MAX(usage_events.timestamp)` instead of a nullable column.
>     - Display derived last-used timestamps in `/ui/me` API key table.
>     - Replace unbounded stream chunk accumulation with `StreamUsageTracker` for metadata tracking in `stream_usage.py`.
>   - **Functions**:
>     - Add `fetch_api_key_last_used_map()` in `usage_queries.py` to derive last-used timestamps.
>     - Update `streaming_response_wrapper()` in `main.py` to use `StreamUsageTracker`.
>   - **Templates**:
>     - Update `me.html` to show derived last-used timestamps.
>   - **Tests**:
>     - Add `test_list_api_keys_uses_derived_last_used_timestamp()` in `test_api_keys.py`.
>     - Add `test_stream_usage_tracker_keeps_only_minimal_metadata()` in `test_stream_usage.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Mirrowel%2FLLM-API-Key-Proxy&utm_source=github&utm_medium=referral)<sup> for 5fd3f9a87cee19d6a94312a8ca1903877ae20f69. You can [customize](https://app.ellipsis.dev/Mirrowel/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->