### PR TITLE
fix(compat): add usage retention pruning and Anthropic error responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,10 @@
 # SQLite lock wait timeout in milliseconds.
 #SQLITE_BUSY_TIMEOUT_MS=5000
 
+# Usage event retention window (days). Older events are pruned on startup and
+# can be pruned manually via POST /api/admin/usage/prune.
+#USAGE_RETENTION_DAYS=30
+
 
 # ------------------------------------------------------------------------------
 # | [API KEYS] Provider API Keys                                               |

--- a/README.md
+++ b/README.md
@@ -243,8 +243,10 @@ print(response.content[0].text)
 | `GET /v1/models` | List all available models with pricing & capabilities |
 | `GET /v1/models/{model_id}` | Get details for a specific model |
 | `GET /v1/providers` | List configured providers |
+| `GET/POST /v1/quota-stats` | Provider quota stats (admin-only actor) |
 | `POST /v1/token-count` | Calculate token count for a payload |
 | `POST /v1/cost-estimate` | Estimate cost based on token counts |
+| `POST /api/admin/usage/prune` | Prune usage events older than `USAGE_RETENTION_DAYS` |
 
 > **Tip:** The `/v1/models` endpoint is useful for discovering available models in your client. Many apps can fetch this list automatically. Add `?enriched=false` for a minimal response without pricing data.
 
@@ -508,6 +510,7 @@ The proxy includes a powerful text-based UI for configuration and management.
 | `CORS_ALLOW_ORIGINS` | Comma-separated browser origins | empty |
 | `CORS_ALLOW_CREDENTIALS` | Allow credentialed CORS requests | false (unless origins configured) |
 | `SQLITE_BUSY_TIMEOUT_MS` | SQLite lock timeout in milliseconds | `5000` |
+| `USAGE_RETENTION_DAYS` | Usage event retention window in days | `30` |
 | `OAUTH_REFRESH_INTERVAL` | Token refresh check interval (seconds) | `600` |
 | `SKIP_OAUTH_INIT_CHECK` | Skip interactive OAuth setup on startup | `false` |
 

--- a/src/proxy_app/anthropic_errors.py
+++ b/src/proxy_app/anthropic_errors.py
@@ -1,0 +1,17 @@
+from fastapi.responses import JSONResponse
+
+
+def anthropic_error_response(
+    *,
+    status_code: int,
+    error_type: str,
+    message: str,
+) -> JSONResponse:
+    payload = {
+        "type": "error",
+        "error": {
+            "type": error_type,
+            "message": message,
+        },
+    }
+    return JSONResponse(status_code=status_code, content=payload)

--- a/tests/test_api_compat.py
+++ b/tests/test_api_compat.py
@@ -1,0 +1,22 @@
+import json
+
+from proxy_app.anthropic_errors import anthropic_error_response
+
+
+def test_anthropic_error_response_shape_is_not_fastapi_wrapped() -> None:
+    response = anthropic_error_response(
+        status_code=429,
+        error_type="rate_limit_error",
+        message="Too many requests",
+    )
+
+    payload = json.loads(response.body.decode("utf-8"))
+    assert response.status_code == 429
+    assert payload == {
+        "type": "error",
+        "error": {
+            "type": "rate_limit_error",
+            "message": "Too many requests",
+        },
+    }
+    assert "detail" not in payload

--- a/tests/test_usage_retention.py
+++ b/tests/test_usage_retention.py
@@ -1,0 +1,49 @@
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import func, select
+
+from proxy_app.db_models import UsageEvent
+from proxy_app.usage_recorder import prune_usage_events
+
+
+@pytest.mark.asyncio
+async def test_prune_usage_events_removes_old_rows(session_maker) -> None:
+    now = datetime.utcnow()
+    old_time = now - timedelta(days=60)
+    recent_time = now - timedelta(days=5)
+
+    async with session_maker() as session:
+        session.add_all(
+            [
+                UsageEvent(
+                    timestamp=old_time,
+                    user_id=1,
+                    api_key_id=1,
+                    endpoint="/v1/chat/completions",
+                    provider="openai",
+                    model="openai/gpt-4o-mini",
+                    request_id="req-old",
+                    status_code=200,
+                ),
+                UsageEvent(
+                    timestamp=recent_time,
+                    user_id=1,
+                    api_key_id=1,
+                    endpoint="/v1/chat/completions",
+                    provider="openai",
+                    model="openai/gpt-4o-mini",
+                    request_id="req-recent",
+                    status_code=200,
+                ),
+            ]
+        )
+        await session.commit()
+
+    deleted = await prune_usage_events(session_maker, retention_days=30)
+    assert deleted == 1
+
+    async with session_maker() as session:
+        count = await session.scalar(select(func.count(UsageEvent.id)))
+
+    assert count == 1


### PR DESCRIPTION
## Summary
- add simple usage retention controls via `USAGE_RETENTION_DAYS` with startup pruning and admin-triggered prune endpoint (`POST /api/admin/usage/prune`)
- return Anthropic-style JSON error payloads directly from `/v1/messages` and `/v1/messages/count_tokens` without FastAPI `detail` wrapping
- document retention and admin-only quota visibility in README and `.env.example`
- add tests for Anthropic error response shape, retention pruning, and admin actor guard regression

## Verification
- `PYTHONPATH=src .venv/bin/python -m py_compile src/proxy_app/usage_recorder.py src/proxy_app/anthropic_errors.py src/proxy_app/routers/admin_api.py src/proxy_app/main.py tests/test_api_compat.py tests/test_usage_retention.py tests/test_auth.py`
- `PYTHONPATH=src .venv/bin/pytest -q tests/test_api_compat.py tests/test_usage_retention.py tests/test_auth.py`
- `PYTHONPATH=src .venv/bin/pytest -q`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds usage retention controls and Anthropic-style error responses, with tests and documentation updates.
> 
>   - **Behavior**:
>     - Adds `USAGE_RETENTION_DAYS` for usage event retention, with startup pruning and `POST /api/admin/usage/prune` for manual pruning.
>     - Updates `/v1/messages` and `/v1/messages/count_tokens` to return Anthropic-style JSON error payloads without FastAPI `detail` wrapping.
>   - **Documentation**:
>     - Documents usage retention and admin-only quota visibility in `README.md` and `.env.example`.
>   - **Testing**:
>     - Adds tests for Anthropic error response shape, retention pruning, and admin actor guard regression.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Mirrowel%2FLLM-API-Key-Proxy&utm_source=github&utm_medium=referral)<sup> for 68d01636ed43f068127ce377d8473e21b2dbe615. You can [customize](https://app.ellipsis.dev/Mirrowel/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->