### PR TITLE
feat(iflow): add support for glm-5, minimax-m2.5, qwen3-32b, tstars2.0, iflow-rome-30ba3b

### DIFF
--- a/src/rotator_library/providers/iflow_provider.py
+++ b/src/rotator_library/providers/iflow_provider.py
@@ -31,25 +31,30 @@ lib_logger = logging.getLogger("rotator_library")
 HARDCODED_MODELS = [
     "glm-4.6",
     "glm-4.7",
-    "minimax-m2",
-    "minimax-m2.1",
-    "qwen3-coder-plus",
+    "glm-5",
+    "iflow-rome-30ba3b",
     "kimi-k2",
     "kimi-k2-0905",
     "kimi-k2-thinking",  # Seems to not work, but should
     "kimi-k2.5",  # Seems to not work, but should
+    "minimax-m2",
+    "minimax-m2.1",
+    "minimax-m2.5",
+    "qwen3-32b",
+    "qwen3-235b",
+    "qwen3-235b-a22b-instruct",
+    "qwen3-235b-a22b-thinking-2507",
+    "qwen3-coder-plus",
     "qwen3-max",
     "qwen3-max-preview",
-    "qwen3-235b-a22b-thinking-2507",
+    "qwen3-vl-plus",
     "deepseek-v3.2-reasoner",
     "deepseek-v3.2-chat",
     "deepseek-v3.2",  # seems to not work, but should. Use above variants instead
     "deepseek-v3.1",
     "deepseek-v3",
     "deepseek-r1",
-    "qwen3-vl-plus",
-    "qwen3-235b-a22b-instruct",
-    "qwen3-235b",
+    "tstars2.0",
 ]
 
 # OpenAI-compatible parameters supported by iFlow API
@@ -83,20 +88,22 @@ IFLOW_HEADER_SIGNATURE = "x-iflow-signature"
 ENABLE_THINKING_MODELS = {
     "glm-4.6",
     "glm-4.7",
+    "glm-5",
     "qwen3-max-preview",
+    "qwen3-32b",
     "deepseek-v3.2",
     "deepseek-v3.1",
 }
 
 # GLM models need additional clear_thinking=false when thinking is enabled
-GLM_MODELS = {"glm-4.6", "glm-4.7"}
+GLM_MODELS = {"glm-4.6", "glm-4.7", "glm-5"}
 
 # Models using reasoning_split (boolean) instead of enable_thinking
-REASONING_SPLIT_MODELS = {"minimax-m2", "minimax-m2.1"}
+REASONING_SPLIT_MODELS = {"minimax-m2", "minimax-m2.1", "minimax-m2.5"}
 
 # Models that benefit from reasoning_content preservation in message history
 # (for multi-turn conversations)
-REASONING_PRESERVATION_MODELS_PREFIXES = ("glm-4", "minimax-m2")
+REASONING_PRESERVATION_MODELS_PREFIXES = ("glm-4", "glm-5", "minimax-m2", "tstars")
 
 # Cache file path for reasoning content preservation
 _REASONING_CACHE_FILE = (
@@ -1022,9 +1029,7 @@ class IFlowProvider(IFlowAuthBase, ProviderInterface):
                         else:
                             if not error_text:
                                 content_type = response.headers.get("content-type", "")
-                                error_text = (
-                                    f"(empty response body, content-type={content_type})"
-                                )
+                                error_text = f"(empty response body, content-type={content_type})"
                             error_msg = (
                                 f"iFlow HTTP {response.status_code} error: {error_text}"
                             )

--- a/src/rotator_library/providers/iflow_provider.py
+++ b/src/rotator_library/providers/iflow_provider.py
@@ -29,6 +29,12 @@ lib_logger = logging.getLogger("rotator_library")
 
 # Model list can be expanded as iFlow supports more models
 HARDCODED_MODELS = [
+    "deepseek-r1",
+    "deepseek-v3",
+    "deepseek-v3.1",
+    "deepseek-v3.2",  # seems to not work, but should. Use -chat/-reasoner variants instead
+    "deepseek-v3.2-chat",
+    "deepseek-v3.2-reasoner",
     "glm-4.6",
     "glm-4.7",
     "glm-5",
@@ -48,12 +54,6 @@ HARDCODED_MODELS = [
     "qwen3-max",
     "qwen3-max-preview",
     "qwen3-vl-plus",
-    "deepseek-v3.2-reasoner",
-    "deepseek-v3.2-chat",
-    "deepseek-v3.2",  # seems to not work, but should. Use above variants instead
-    "deepseek-v3.1",
-    "deepseek-v3",
-    "deepseek-r1",
     "tstars2.0",
 ]
 
@@ -103,7 +103,13 @@ REASONING_SPLIT_MODELS = {"minimax-m2", "minimax-m2.1", "minimax-m2.5"}
 
 # Models that benefit from reasoning_content preservation in message history
 # (for multi-turn conversations)
-REASONING_PRESERVATION_MODELS_PREFIXES = ("glm-4", "glm-5", "minimax-m2", "tstars")
+REASONING_PRESERVATION_MODELS_PREFIXES = (
+    "deepseek",
+    "glm-",
+    "minimax-",
+    "qwen",
+    "tstars",
+)
 
 # Cache file path for reasoning content preservation
 _REASONING_CACHE_FILE = (
@@ -427,7 +433,7 @@ class IFlowProvider(IFlowAuthBase, ProviderInterface):
         """
         Inject cached reasoning_content into assistant messages.
 
-        Only for models that benefit from reasoning preservation (GLM-4.x, MiniMax-M2.x).
+        Only for models that benefit from reasoning preservation.
         This is helpful for multi-turn conversations where the model may benefit
         from seeing its previous reasoning to maintain coherent thought chains.
 

--- a/src/rotator_library/providers/iflow_provider.py
+++ b/src/rotator_library/providers/iflow_provider.py
@@ -104,11 +104,13 @@ REASONING_SPLIT_MODELS = {"minimax-m2", "minimax-m2.1", "minimax-m2.5"}
 # Models that benefit from reasoning_content preservation in message history
 # (for multi-turn conversations)
 REASONING_PRESERVATION_MODELS_PREFIXES = (
-    "deepseek",
-    "glm-",
-    "minimax-",
-    "qwen",
+    "glm-4",
+    "glm-5",
+    "minimax-m2",
     "tstars",
+    "qwen3-32b",
+    "deepseek-v3.1",
+    "deepseek-v3.2",
 )
 
 # Cache file path for reasoning content preservation


### PR DESCRIPTION
## Summary

Add support for 5 new iFlow models to maintain feature parity: glm-5, minimax-m2.5, qwen3-32b, tstars2.0, and iflow-rome-30ba3b. Each model is registered with appropriate thinking, reasoning, and preservation configurations.

## Changes

- Add `glm-5`, `minimax-m2.5`, `qwen3-32b`, `tstars2.0`, and `iflow-rome-30ba3b` to `HARDCODED_MODELS`
- Add `glm-5` to `ENABLE_THINKING_MODELS` and `GLM_MODELS` sets
- Add `qwen3-32b` to `ENABLE_THINKING_MODELS` set
- Add `minimax-m2.5` to `REASONING_SPLIT_MODELS` set
- Update `REASONING_PRESERVATION_MODELS_PREFIXES` with `glm-5` and `tstars` prefixes
- Sort `HARDCODED_MODELS` list alphabetically by model family for consistency

## Files Changed

| File | Type | Impact |
| ---- | ---- | ------ |
| `src/rotator_library/providers/iflow_provider.py` | Modified | Register 5 new models with correct thinking/reasoning configurations |

## Testing Instructions

1. Verify each new model appears in the model list endpoint
2. Test `glm-5` — should send `enable_thinking` + `clear_thinking=false` (GLM-style)
3. Test `minimax-m2.5` — should use `reasoning_split` instead of `enable_thinking`
4. Test `qwen3-32b` — should send `enable_thinking`
5. Test `tstars2.0` and `iflow-rome-30ba3b` — standard chat completions

Tested right now:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1dd5ebc0-3f06-483d-8cfb-3465fb3b9e61" />


Closes #129
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for new iFlow models `glm-5`, `minimax-m2.5`, `qwen3-32b`, `tstars2.0`, and `iflow-rome-30ba3b` with appropriate configurations in `iflow_provider.py`.
> 
>   - **Models**:
>     - Add `glm-5`, `minimax-m2.5`, `qwen3-32b`, `tstars2.0`, `iflow-rome-30ba3b` to `HARDCODED_MODELS` in `iflow_provider.py`.
>     - Add `glm-5` to `ENABLE_THINKING_MODELS` and `GLM_MODELS`.
>     - Add `qwen3-32b` to `ENABLE_THINKING_MODELS`.
>     - Add `minimax-m2.5` to `REASONING_SPLIT_MODELS`.
>     - Update `REASONING_PRESERVATION_MODELS_PREFIXES` with `glm-5` and `tstars` prefixes.
>   - **Misc**:
>     - Sort `HARDCODED_MODELS` alphabetically by model family.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Mirrowel%2FLLM-API-Key-Proxy&utm_source=github&utm_medium=referral)<sup> for 87b894bbdcf5daf6e8602edbfcd2d563dfa376a4. You can [customize](https://app.ellipsis.dev/Mirrowel/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->