### PR TITLE
fix: condense 429 error logging and suppress litellm Provider List spam

### DIFF
--- a/src/proxy_app/main.py
+++ b/src/proxy_app/main.py
@@ -627,6 +627,7 @@ async def lifespan(app: FastAPI):
 
     os.environ["LITELLM_LOG"] = "ERROR"
     litellm.set_verbose = False
+    litellm.suppress_debug_info = True
     litellm.drop_params = True
     if USE_EMBEDDING_BATCHER:
         batcher = EmbeddingBatcher(client=client)

--- a/src/rotator_library/providers/gemini_cli_provider.py
+++ b/src/rotator_library/providers/gemini_cli_provider.py
@@ -1530,12 +1530,36 @@ class GeminiCliProvider(
                             if response.status_code >= 400:
                                 try:
                                     error_body = await response.aread()
-                                    lib_logger.error(
-                                        f"Gemini CLI API error {response.status_code}: {error_body.decode()}"
-                                    )
+                                    error_text = error_body.decode()
+                                    # Always log full body to transaction file for debugging
                                     file_logger.log_error(
-                                        f"API error {response.status_code}: {error_body.decode()}"
+                                        f"API error {response.status_code}: {error_text}"
                                     )
+                                    # Console logging: condensed for 429s, full for other errors
+                                    if response.status_code == 429:
+                                        # Extract key fields for a single-line summary
+                                        try:
+                                            err_json = json.loads(error_text)
+                                            err_msg = err_json.get("error", {}).get("message", "")
+                                            # Extract quotaResetDelay from details
+                                            reset_delay = ""
+                                            for detail in err_json.get("error", {}).get("details", []):
+                                                metadata = detail.get("metadata", {})
+                                                if "quotaResetDelay" in metadata:
+                                                    reset_delay = metadata["quotaResetDelay"]
+                                                    break
+                                            summary = f"Gemini CLI 429: {err_msg}"
+                                            if reset_delay:
+                                                summary += f" (resetDelay: {reset_delay})"
+                                            lib_logger.warning(summary)
+                                        except (json.JSONDecodeError, KeyError):
+                                            lib_logger.warning(
+                                                f"Gemini CLI 429: {error_text[:200]}"
+                                            )
+                                    else:
+                                        lib_logger.error(
+                                            f"Gemini CLI API error {response.status_code}: {error_text}"
+                                        )
                                 except Exception:
                                     pass
 


### PR DESCRIPTION
two small logging "fixes"/improvements. 

Issue 1: Gemini CLI 429 errors were dumping the full JSON error body across 20+ lines of console output. Now extracts key info (message, quotaResetDelay) into a single warning line. Full body still logged to transaction file.

Issue 2: litellm prints 'Provider List: https://docs.litellm.ai/docs/providers' when custom OpenAI-compatible providers aren't in its known model list. Set litellm.suppress_debug_info = True to silence this.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Condense Gemini CLI 429 error logs and suppress litellm provider list log to improve console readability.
> 
>   - **Logging Improvements**:
>     - Condense Gemini CLI 429 error logs in `gemini_cli_provider.py` to a single console line with key info (message, quotaResetDelay), while logging full error body to transaction file.
>     - Suppress litellm provider list log in `main.py` by setting `litellm.suppress_debug_info = True`.
>   - **Behavior**:
>     - Console output for 429 errors now shows a single-line summary instead of full JSON body.
>     - Full error details are still logged to the transaction file for debugging purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Mirrowel%2FLLM-API-Key-Proxy&utm_source=github&utm_medium=referral)<sup> for 8e4844c8ae5e2f01fb6577fa0923b1949e0c5cd2. You can [customize](https://app.ellipsis.dev/Mirrowel/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->