### PR TITLE
Add codex oauth support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,30 @@
 # 'Authorization' header as a Bearer token (e.g., "Authorization: Bearer YOUR_PROXY_API_KEY").
 #PROXY_API_KEY="YOUR_PROXY_API_KEY"
 
+# ------------------------------------------------------------------------------
+# | [SECURITY] CORS Configuration                                              |
+# ------------------------------------------------------------------------------
+#
+# Control Cross-Origin Resource Sharing (CORS) for browser-based clients.
+# For production, set explicit origins instead of wildcard (*).
+#
+#PROXY_CORS_ORIGINS="https://yourdomain.com,https://app.yourdomain.com"
+#PROXY_CORS_CREDENTIALS="false"
+#
+# Default: PROXY_CORS_ORIGINS="*" (all origins allowed - INSECURE for production)
+# Default: PROXY_CORS_CREDENTIALS="false"
+
+# ------------------------------------------------------------------------------
+# | [PERFORMANCE] Model List Cache                                             |
+# ------------------------------------------------------------------------------
+#
+# TTL for the /v1/models endpoint cache. Models are cached per-provider to
+# avoid repeated API calls. Cache is invalidated on credential refresh.
+#
+#MODEL_LIST_CACHE_TTL="300"
+#
+# Default: 300 seconds (5 minutes)
+
 
 # ------------------------------------------------------------------------------
 # | [API KEYS] Provider API Keys                                               |

--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,32 @@
 # Path to your iFlow credential file (e.g., ~/.iflow/oauth_creds.json).
 #IFLOW_OAUTH_1=""
 
+# --- OpenAI Codex (ChatGPT OAuth) ---
+# One-time import from Codex CLI auth files (copied into oauth_creds/openai_codex_oauth_*.json)
+#OPENAI_CODEX_OAUTH_1="~/.codex/auth.json"
+
+# Stateless env credentials (legacy single account)
+#OPENAI_CODEX_ACCESS_TOKEN=""
+#OPENAI_CODEX_REFRESH_TOKEN=""
+#OPENAI_CODEX_EXPIRY_DATE="0"
+#OPENAI_CODEX_ID_TOKEN=""
+#OPENAI_CODEX_ACCOUNT_ID=""
+#OPENAI_CODEX_EMAIL=""
+
+# Stateless env credentials (numbered multi-account)
+#OPENAI_CODEX_1_ACCESS_TOKEN=""
+#OPENAI_CODEX_1_REFRESH_TOKEN=""
+#OPENAI_CODEX_1_EXPIRY_DATE="0"
+#OPENAI_CODEX_1_ID_TOKEN=""
+#OPENAI_CODEX_1_ACCOUNT_ID=""
+#OPENAI_CODEX_1_EMAIL=""
+
+# OpenAI Codex routing/config
+#OPENAI_CODEX_API_BASE="https://chatgpt.com/backend-api"
+#OPENAI_CODEX_OAUTH_PORT=1455
+#OPENAI_CODEX_MODELS='["gpt-5.1-codex","gpt-5-codex"]'
+#ROTATION_MODE_OPENAI_CODEX=sequential
+
 
 # ------------------------------------------------------------------------------
 # | [ADVANCED] Provider-Specific Settings                                      |
@@ -162,6 +188,7 @@
 #
 # Provider Defaults:
 #   - antigravity: sequential (free tier accounts with daily quotas)
+#   - openai_codex: sequential (account-level quota behavior)
 #   - All others: balanced
 #
 # Example:
@@ -401,8 +428,24 @@
 # ------------------------------------------------------------------------------
 #
 # OAuth callback port for Antigravity interactive re-authentication.
-# Default: 8085 (same as Gemini CLI, shared)
-# ANTIGRAVITY_OAUTH_PORT=8085
+# Default: 51121
+# ANTIGRAVITY_OAUTH_PORT=51121
+
+# ------------------------------------------------------------------------------
+# | [ADVANCED] iFlow OAuth Configuration                                        |
+# ------------------------------------------------------------------------------
+#
+# OAuth callback port for iFlow interactive re-authentication.
+# Default: 11451
+# IFLOW_OAUTH_PORT=11451
+
+# ------------------------------------------------------------------------------
+# | [ADVANCED] OpenAI Codex OAuth Configuration                                 |
+# ------------------------------------------------------------------------------
+#
+# OAuth callback port for OpenAI Codex interactive authentication.
+# Default: 1455
+# OPENAI_CODEX_OAUTH_PORT=1455
 
 # ------------------------------------------------------------------------------
 # | [ADVANCED] Debugging / Logging                                              |

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1676,6 +1676,7 @@ QUOTA_GROUPS_GEMINI_CLI_3_FLASH="gemini-3-flash-preview"
 ### 3.4. OpenAI Codex (`openai_codex_provider.py`)
 
 *   **Auth Base**: Uses `OpenAICodexAuthBase` with Authorization Code + PKCE, queue-based refresh/re-auth, and local-first credential persistence (`oauth_creds/openai_codex_oauth_*.json`).
+*   **OAuth Client ID**: Uses OpenAI's public Codex OAuth client ID. This value is intentionally non-secret (OAuth client IDs identify the app, unlike client secrets).
 *   **First-Run Import**: `CredentialManager` imports from `~/.codex/auth.json` and `~/.codex-accounts.json` when no local/OpenAI Codex env creds exist.
 *   **Endpoint Translation**: Implements OpenAI-compatible `/v1/chat/completions` by transforming chat payloads into Codex Responses payloads and calling `POST /codex/responses`.
 *   **SSE Translation**: Maps Codex SSE event families (e.g. `response.output_item.*`, `response.output_text.delta`, `response.function_call_arguments.*`, `response.completed`) into LiteLLM/OpenAI chunk objects.

--- a/PLAN-openai-codex.md
+++ b/PLAN-openai-codex.md
@@ -1,0 +1,459 @@
+# PLAN: OpenAI Codex OAuth + Multi-Account Support (Revised)
+
+## Goal
+Add first-class `openai_codex` support to LLM-API-Key-Proxy with:
+- OAuth login + token refresh
+- file/env credential loading
+- multi-account rotation via existing `UsageManager`
+- OpenAI-compatible `/v1/chat/completions` served through Codex Responses backend
+- first-run import from existing Codex CLI credentials (`~/.codex/auth.json`, `~/.codex-accounts.json`)
+
+---
+
+## Review updates applied in this revision
+
+- Aligned with current local-first architecture: **local managed creds stay in `oauth_creds/`**, not `~/.openai_codex`.
+- Reduced MVP risk: **no cross-provider OAuth base refactor in phase 1**.
+- Added protocol validation gate (headers/endpoints/SSE event taxonomy) before implementation.
+- Expanded wiring checklist to all known hardcoded OAuth provider lists (credential tool, launcher TUI, settings tool).
+- Added explicit `env://openai_codex/N` parity requirements and test-harness bootstrap work.
+
+---
+
+## 0) Scope decisions + preflight validation (must lock before coding)
+
+### 0.1 Provider identity and defaults
+
+- [x] Provider key: `openai_codex`
+- [x] OAuth env prefix: `OPENAI_CODEX`
+- [x] Default API base: `https://chatgpt.com/backend-api`
+- [x] Responses endpoint path: `/codex/responses`
+- [x] Default rotation mode for provider: `sequential`
+- [x] Callback env var: `OPENAI_CODEX_OAUTH_PORT`
+- [x] JWT parsing strategy: unverified base64url decode (no `PyJWT` dependency)
+
+### 0.2 Architecture alignment (critical)
+
+- [x] Keep **local managed credentials** in project data dir: `oauth_creds/openai_codex_oauth_N.json`
+  - [x] Match existing patterns in `src/rotator_library/utils/paths.py` and other auth bases
+  - [x] Do **not** introduce a new default managed dir under `~/.openai_codex` for MVP
+- [x] Treat `~/.codex/*` only as **import source**, never as primary writable store
+
+### 0.3 Protocol truth capture (before implementation)
+
+- [x] Capture one successful non-stream + stream Codex call and confirm:
+  - [x] Auth endpoint(s) and token exchange params
+  - [x] Required request headers (`chatgpt-account-id`, `OpenAI-Beta`, `originator`, etc.)
+  - [x] SSE event names/payload shapes
+  - [x] Error body format for 401/403/429/5xx
+- [x] Save representative payloads/events as test fixtures under `tests/fixtures/openai_codex/`
+
+---
+
+## 1) OAuth + credential plumbing
+
+## 1.1 Add OpenAI Codex auth base (MVP approach: provider-specific class)
+
+- [x] Create `src/rotator_library/providers/openai_codex_auth_base.py`
+- [x] Base implementation strategy for MVP:
+  - [x] Adapt proven queue/refresh/reauth approach from `qwen_auth_base.py` / `iflow_auth_base.py`
+  - [x] **Do not** refactor `GoogleOAuthBase` or create shared `oauth_base.py` in phase 1
+
+### 1.1.1 Core lifecycle and queue infrastructure
+
+- [x] Implement credential cache/locking/queue internals:
+  - [x] `_credentials_cache`, `_load_credentials()`, `_save_credentials()`
+  - [x] `_refresh_locks`, `_locks_lock`, `_get_lock()`
+  - [x] `_refresh_queue`, `_reauth_queue`
+  - [x] `_queue_refresh()`, `_process_refresh_queue()`, `_process_reauth_queue()`
+  - [x] `_refresh_failures`, `_next_refresh_after` (backoff tracking)
+  - [x] `_queued_credentials`, `_unavailable_credentials`, TTL cleanup
+- [x] Implement `is_credential_available(path)` with:
+  - [x] re-auth queue exclusion
+  - [x] true-expiry check (not proactive buffer)
+- [x] Implement `proactively_refresh(credential_identifier)` queue-based behavior
+
+### 1.1.2 OAuth flow and refresh behavior
+
+- [x] Interactive OAuth with PKCE + state
+  - [x] Local callback: `http://localhost:{OPENAI_CODEX_OAUTH_PORT}/oauth2callback`
+  - [x] `ReauthCoordinator` integration (single interactive flow globally)
+- [x] Token exchange endpoint: `https://auth.openai.com/oauth/token`
+- [x] Authorization endpoint: `https://auth.openai.com/oauth/authorize`
+- [x] Refresh flow (`grant_type=refresh_token`) with retry/backoff (3 attempts)
+- [x] Refresh error handling:
+  - [x] `400 invalid_grant` => queue re-auth + raise `CredentialNeedsReauthError`
+  - [x] `401/403` => queue re-auth + raise `CredentialNeedsReauthError`
+  - [x] `429` => honor `Retry-After`
+  - [x] `5xx` => exponential backoff retry
+
+### 1.1.3 Safe persistence semantics (critical)
+
+- [x] `_save_credentials()` uses `safe_write_json(..., secure_permissions=True)`
+- [x] For rotating refresh-token safety:
+  - [x] Write-to-disk success required before cache mutation for refreshed tokens
+  - [x] Avoid stale-cache overwrite scenarios
+- [x] Env-backed credentials (`_proxy_metadata.loaded_from_env=true`) skip disk writes safely
+
+### 1.1.4 JWT and metadata extraction
+
+- [x] Add unverified JWT decode helper (base64url payload decode with padding)
+- [x] Extract from access token (fallback to `id_token`):
+  - [x] `account_id` claim: `https://api.openai.com/auth.chatgpt_account_id`
+  - [x] email claim fallback chain: `email` -> `sub`
+  - [x] `exp` for token expiry
+- [x] Maintain metadata under `_proxy_metadata`:
+  - [x] `email`, `account_id`, `last_check_timestamp`
+  - [x] `loaded_from_env`, `env_credential_index`
+
+### 1.1.5 Env credential support
+
+- [x] Support both formats in `_load_from_env()`:
+  - [x] legacy single: `OPENAI_CODEX_ACCESS_TOKEN`, `OPENAI_CODEX_REFRESH_TOKEN`, ...
+  - [x] numbered: `OPENAI_CODEX_1_ACCESS_TOKEN`, `OPENAI_CODEX_1_REFRESH_TOKEN`, ...
+- [x] Implement `_parse_env_credential_path(path)` for `env://openai_codex/N`
+- [x] Ensure `_load_credentials()` works for file paths **and** `env://` virtual paths
+
+### 1.1.6 Public methods expected by tooling/runtime
+
+- [x] `setup_credential()`
+- [x] `initialize_token(path_or_creds, force_interactive=False)`
+- [x] `get_user_info(creds_or_path)`
+- [x] `get_auth_header(credential_identifier)`
+- [x] `list_credentials(base_dir)`
+- [x] `delete_credential(path)`
+- [x] `build_env_lines(creds, cred_number)`
+- [x] `export_credential_to_env(credential_path, base_dir)` (used by credential tool export flows)
+- [x] `_get_provider_file_prefix() -> "openai_codex"`
+
+### 1.1.7 Credential schema (`openai_codex_oauth_N.json`)
+
+```json
+{
+  "access_token": "eyJhbGciOi...",
+  "refresh_token": "rt_...",
+  "id_token": "eyJhbGciOi...",
+  "expiry_date": 1739400000000,
+  "token_uri": "https://auth.openai.com/oauth/token",
+  "_proxy_metadata": {
+    "email": "user@example.com",
+    "account_id": "acct_...",
+    "last_check_timestamp": 1739396400.0,
+    "loaded_from_env": false,
+    "env_credential_index": null
+  }
+}
+```
+
+> Note: client metadata like `client_id` should be class constants unless Codex token refresh explicitly requires persisted values.
+
+---
+
+## 1.2 First-run import from Codex CLI credentials (CredentialManager integration)
+
+- [x] Update `src/rotator_library/credential_manager.py` to add Codex import helper
+  - [x] Trigger only when:
+    - [x] provider is `openai_codex`
+    - [x] no local `oauth_creds/openai_codex_oauth_*.json`
+    - [x] no env-based OpenAI Codex credentials already selected
+- [x] Import sources (read-only):
+  - [x] `~/.codex/auth.json` (single account)
+  - [x] `~/.codex-accounts.json` (multi-account)
+- [x] Normalize imported records to proxy schema
+- [x] Extract and store `account_id` + email from JWT claims during import
+- [x] Skip malformed entries gracefully with warnings
+- [x] Preserve original source files untouched
+- [x] Log import summary (count + identifiers)
+
+---
+
+## 1.3 Wire registries and discovery maps
+
+- [x] Update `src/rotator_library/provider_factory.py`
+  - [x] Import `OpenAICodexAuthBase`
+  - [x] Add `"openai_codex": OpenAICodexAuthBase` to `PROVIDER_MAP`
+- [x] Update `src/rotator_library/credential_manager.py`
+  - [x] Add to `DEFAULT_OAUTH_DIRS`: `"openai_codex": Path.home() / ".codex"` (source import context)
+  - [x] Add to `ENV_OAUTH_PROVIDERS`: `"openai_codex": "OPENAI_CODEX"`
+
+---
+
+## 1.4 Wire credential UI, launcher UI, and settings UI
+
+### 1.4.1 Credential tool updates (`src/rotator_library/credential_tool.py`)
+
+- [x] Add to `OAUTH_FRIENDLY_NAMES`: `"openai_codex": "OpenAI Codex"`
+- [x] Add to OAuth provider lists:
+  - [x] `_get_oauth_credentials_summary()` hardcoded list
+  - [x] `combine_all_credentials()` hardcoded list
+- [x] Add to OAuth-only exclusions in API-key flow:
+  - [x] `oauth_only_providers` in `setup_api_key()`
+- [x] Add to setup display mapping in `setup_new_credential()`
+- [x] Export support:
+  - [x] Add OpenAI Codex export option(s) or refactor export menu to provider-driven generic flow
+  - [x] Ensure combine/export features call new auth-base methods
+
+### 1.4.2 Launcher TUI updates (`src/proxy_app/launcher_tui.py`)
+
+- [x] Add `"openai_codex": "OPENAI_CODEX"` to `env_oauth_providers` in `SettingsDetector.detect_credentials()`
+
+### 1.4.3 Settings tool updates (`src/proxy_app/settings_tool.py`)
+
+- [x] Import Codex default callback port from auth class with fallback constant
+- [x] Add provider settings block for `openai_codex`:
+  - [x] `OPENAI_CODEX_OAUTH_PORT`
+- [x] Register `openai_codex` in `PROVIDER_SETTINGS_MAP`
+
+---
+
+## 1.5 Provider plugin auto-registration verification
+
+- [x] Create `src/rotator_library/providers/openai_codex_provider.py`
+  - [x] Confirm `providers/__init__.py` auto-registers as `openai_codex`
+- [x] Verify name consistency across all maps/lists:
+  - [x] `PROVIDER_MAP` (`provider_factory.py`)
+  - [x] `DEFAULT_OAUTH_DIRS` / `ENV_OAUTH_PROVIDERS` (`credential_manager.py`)
+  - [x] `OAUTH_FRIENDLY_NAMES` + hardcoded OAuth lists (`credential_tool.py`)
+  - [x] `env_oauth_providers` (`launcher_tui.py`)
+  - [x] `PROVIDER_SETTINGS_MAP` (`settings_tool.py`)
+
+---
+
+## 2) Codex inference provider (`openai_codex_provider.py`)
+
+## 2.1 Provider class skeleton
+
+- [x] Implement `OpenAICodexProvider(OpenAICodexAuthBase, ProviderInterface)`
+- [x] Set class behavior:
+  - [x] `has_custom_logic() -> True`
+  - [x] `skip_cost_calculation = True`
+  - [x] `default_rotation_mode = "sequential"`
+  - [x] `provider_env_name = "openai_codex"`
+- [x] `get_models()` model source order:
+  - [x] `OPENAI_CODEX_MODELS` via `ModelDefinitions` (priority)
+  - [x] hardcoded sane fallback models
+  - [x] optional dynamic discovery if Codex endpoint supports model listing
+
+## 2.2 Credential initialization + metadata cache
+
+- [x] Implement `initialize_credentials(credential_paths)` startup hook:
+  - [x] preload credentials (file + `env://`)
+  - [x] validate expiry and queue refresh where needed
+  - [x] parse/cache `account_id` and email
+  - [x] log summary of ready/refreshing/reauth-required credentials
+
+## 2.3 Non-streaming completion path
+
+- [x] Implement `acompletion()` for `stream=false`
+- [x] Credential handling:
+  - [x] use `credential_identifier` from client
+  - [x] support file + `env://` paths consistently (no `os.path.isfile` shortcut assumptions)
+  - [x] ensure `initialize_token()` called before request when needed
+- [x] Transform incoming OpenAI chat payload to Codex Responses payload:
+  - [x] `messages` -> Codex `input`
+  - [x] `model`, `temperature`, `top_p`, `max_tokens`
+  - [x] tools/tool_choice mapping where supported
+- [x] Request target:
+  - [x] `POST ${OPENAI_CODEX_API_BASE or default}/codex/responses`
+- [x] Required headers:
+  - [x] `Authorization: Bearer <access_token>`
+  - [x] `chatgpt-account-id: <account_id>`
+  - [x] protocol-validated beta/originator headers from preflight
+- [x] Parse response into `litellm.ModelResponse`
+
+## 2.4 Streaming path + SSE translation
+
+- [x] Implement dedicated SSE parser/translator
+- [x] Handle expected Codex event families (validated from fixtures):
+  - [x] `response.created`
+  - [x] `response.output_item.added`
+  - [x] `response.content_part.added`
+  - [x] `response.content_part.delta`
+  - [x] `response.content_part.done`
+  - [x] `response.output_item.done`
+  - [x] `response.completed`
+  - [x] `response.failed` / `response.incomplete`
+  - [x] `error`
+- [x] Tool-call delta mapping:
+  - [x] `response.function_call_arguments.delta`
+  - [x] `response.function_call_arguments.done`
+- [x] Emit translated `litellm.ModelResponse` chunks (not raw SSE strings)
+  - [x] compatible with `RotatingClient._safe_streaming_wrapper()`
+- [x] Finish reason mapping:
+  - [x] stop -> `stop`
+  - [x] max_output_tokens -> `length`
+  - [x] tool_calls -> `tool_calls`
+  - [x] content_filter -> `content_filter`
+- [x] Usage extraction from terminal event:
+  - [x] `input_tokens` -> `usage.prompt_tokens`
+  - [x] `output_tokens` -> `usage.completion_tokens`
+  - [x] `total_tokens` -> `usage.total_tokens`
+- [x] Unknown events:
+  - [x] ignore safely with debug logs
+  - [x] do not break stream unless terminal error condition
+
+## 2.5 Error classification + rotation compatibility
+
+- [x] Ensure HTTP errors surface as `httpx.HTTPStatusError` (or equivalent classified exceptions)
+- [x] Validate classification in existing `classify_error()` flow (`error_handler.py`):
+  - [x] 401/403 => authentication/forbidden -> rotate credential
+  - [x] 429 => rate_limit/quota_exceeded -> cooldown/rotate
+  - [x] 5xx => server_error -> retry/rotate
+  - [x] context-length style 400 => `context_window_exceeded`
+- [x] Implement `@staticmethod parse_quota_error(error, error_body=None)` on provider
+  - [x] parse `Retry-After`
+  - [x] parse Codex-specific quota payload fields if present
+
+## 2.6 Quota/tier placeholders (MVP-safe defaults)
+
+- [x] Add conservative placeholders:
+  - [x] `tier_priorities`
+  - [x] `usage_reset_configs`
+  - [x] `model_quota_groups`
+- [x] Mark with TODOs for empirical tuning once real quota behavior is observed
+
+---
+
+## 3) Configuration + documentation updates
+
+## 3.1 `.env.example`
+
+- [x] Add one-time file import path:
+  - [x] `OPENAI_CODEX_OAUTH_1`
+- [x] Add stateless env credential vars (legacy + numbered):
+  - [x] `OPENAI_CODEX_ACCESS_TOKEN`
+  - [x] `OPENAI_CODEX_REFRESH_TOKEN`
+  - [x] `OPENAI_CODEX_EXPIRY_DATE`
+  - [x] `OPENAI_CODEX_ID_TOKEN`
+  - [x] `OPENAI_CODEX_ACCOUNT_ID`
+  - [x] `OPENAI_CODEX_EMAIL`
+  - [x] `OPENAI_CODEX_1_*` variants
+- [x] Add routing/config vars:
+  - [x] `OPENAI_CODEX_API_BASE`
+  - [x] `OPENAI_CODEX_OAUTH_PORT`
+  - [x] `OPENAI_CODEX_MODELS`
+  - [x] `ROTATION_MODE_OPENAI_CODEX`
+
+## 3.2 `README.md`
+
+- [x] Add OpenAI Codex to OAuth provider lists/tables
+- [x] Add setup instructions:
+  - [x] interactive OAuth flow
+  - [x] first-run auto-import from `~/.codex/*`
+  - [x] env-based stateless deployment format
+- [x] Add callback-port table row for OpenAI Codex
+
+## 3.3 `DOCUMENTATION.md`
+
+- [x] Update credential discovery/import flow to include Codex source files
+- [x] Add OpenAI Codex auth/provider architecture section
+- [x] Document schema + env vars + runtime refresh/rotation behavior
+- [x] Add troubleshooting section:
+  - [x] malformed JWT payload
+  - [x] missing account-id claim
+  - [x] callback port conflicts
+  - [x] header mismatch / 403 failures
+
+---
+
+## 4) Tests
+
+## 4.0 Test harness bootstrap (repo currently has no test suite)
+
+- [x] Add test directory structure: `tests/`
+- [x] Add test dependencies (`pytest`, `pytest-asyncio`, `respx` or equivalent)
+- [x] Add minimal test run documentation/command
+
+## 4.1 Auth base tests (`tests/test_openai_codex_auth.py`)
+
+- [x] JWT decode helper:
+  - [x] valid token
+  - [x] malformed token
+  - [x] missing claims
+- [x] expiry logic:
+  - [x] `_is_token_expired()` with proactive buffer
+  - [x] `_is_token_truly_expired()` strict expiry
+- [x] env loading:
+  - [x] legacy vars
+  - [x] numbered vars
+  - [x] `env://openai_codex/N` parsing
+- [x] save/load round-trip with `_proxy_metadata`
+- [x] re-auth queue availability behavior (`is_credential_available`)
+
+## 4.2 Import tests (`tests/test_openai_codex_import.py`)
+
+- [x] import from `~/.codex/auth.json` format
+- [x] import from `~/.codex-accounts.json` format
+- [x] skip import when local `openai_codex_oauth_*.json` exists
+- [x] malformed source files handled gracefully
+- [x] source files never modified
+
+## 4.3 Provider request mapping tests (`tests/test_openai_codex_provider.py`)
+
+- [x] chat request mapping to Codex Responses payload
+- [x] non-stream response mapping to `ModelResponse`
+- [x] header construction includes account-id + auth headers
+- [x] env credential identifiers work (no file-only assumptions)
+
+## 4.4 SSE translation tests (`tests/test_openai_codex_sse.py`)
+
+- [x] fixture-driven event sequence -> expected chunk sequence
+- [x] content deltas
+- [x] tool-call deltas
+- [x] finish reason mapping
+- [x] usage extraction
+- [x] error event propagation
+- [x] unknown event tolerance
+
+## 4.5 Wiring regression tests (lightweight)
+
+- [x] credential discovery recognizes OpenAI Codex env vars
+- [x] provider_factory returns OpenAICodexAuthBase
+- [x] `providers` auto-registration includes `openai_codex`
+
+---
+
+## 5) Manual smoke-test checklist
+
+- [x] `python -m rotator_library.credential_tool` shows **OpenAI Codex** in OAuth setup list
+- [x] OpenAI Codex is excluded from API-key setup list (`oauth_only_providers`)
+- [x] first run with no local creds imports from `~/.codex/*` into `oauth_creds/openai_codex_oauth_*.json`
+- [x] env-based `env://openai_codex/N` credentials are detected and used
+- [x] `/v1/models` includes `openai_codex/*` models
+- [x] `/v1/chat/completions` works for:
+  - [x] `stream=false`
+  - [x] `stream=true`
+- [x] expired token refresh works (proactive + on-demand)
+- [x] invalid refresh token queues re-auth and rotates to next credential
+- [x] `is_credential_available()` returns false for re-auth queued / truly expired creds
+- [x] multi-account rotation works in:
+  - [x] `sequential` (default)
+  - [x] `balanced` (override)
+- [x] launcher/settings UIs show Codex OAuth counts and callback-port setting correctly
+
+---
+
+## 6) Optional phase 2 (post-MVP)
+
+- [ ] Extract common OAuth queue/cache logic into shared base mixin for `google_oauth_base`, `qwen_auth_base`, `iflow_auth_base`, and Codex
+- [ ] Refactor credential tool OAuth provider lists/exports to dynamic provider-driven implementation
+- [ ] Add `model_info_service` alias mapping for `openai_codex` if pricing/capability enrichment is desired
+- [ ] Tune tier priorities/quota windows from observed production behavior
+- [ ] Add periodic background reconciliation from external `~/.codex` stores if needed
+
+---
+
+## Proposed implementation order
+
+1. **Protocol validation gate** — lock endpoints/headers/events from real fixtures
+2. **Auth base** — `openai_codex_auth_base.py` (queue + refresh + reauth + env support)
+3. **First-run import** — CredentialManager import flow for `~/.codex/*`
+4. **Registry/discovery wiring** — provider_factory + credential_manager maps
+5. **UI wiring** — credential_tool + launcher_tui + settings_tool
+6. **Provider skeleton** — `openai_codex_provider.py`, model list, startup init
+7. **Non-streaming completion** — request mapping + response mapping
+8. **Streaming translator** — SSE event translation + tool calls + usage
+9. **Error/quota integration** — `parse_quota_error`, retry/cooldown compatibility
+10. **Tests** — harness + auth/import/provider/SSE/wiring tests
+11. **Docs/config** — `.env.example`, `README.md`, `DOCUMENTATION.md`
+12. **Manual smoke validation** — end-to-end checklist

--- a/PLAN-openai-codex.md
+++ b/PLAN-openai-codex.md
@@ -76,7 +76,7 @@ Add first-class `openai_codex` support to LLM-API-Key-Proxy with:
 ### 1.1.2 OAuth flow and refresh behavior
 
 - [x] Interactive OAuth with PKCE + state
-  - [x] Local callback: `http://localhost:{OPENAI_CODEX_OAUTH_PORT}/oauth2callback`
+  - [x] Local callback: `http://localhost:{OPENAI_CODEX_OAUTH_PORT}/auth/callback`
   - [x] `ReauthCoordinator` integration (single interactive flow globally)
 - [x] Token exchange endpoint: `https://auth.openai.com/oauth/token`
 - [x] Authorization endpoint: `https://auth.openai.com/oauth/authorize`

--- a/PLAN-refactor-performance-hardening.md
+++ b/PLAN-refactor-performance-hardening.md
@@ -1,0 +1,567 @@
+# PLAN: Refactor, Performance Enhancements, and Reliability Hardening
+
+## TL;DR
+
+This plan addresses the highest-value opportunities identified in the proxy and rotator library: correctness bugs (token counting + embedding usage accounting), streaming-path performance overhead, async-loop blocking I/O, cache/task amplification risks, security hardening, and maintainability refactors for oversized modules.  
+Work is sequenced so low-risk/high-impact fixes land first, followed by structural refactors and test coverage expansion.  
+The plan is implementation-ready and includes milestones, file-level references, validation criteria, and rollback-safe phases.
+
+---
+
+## 1) Objectives
+
+### Primary goals
+- Improve runtime performance under streaming and high-concurrency load.
+- Fix correctness issues that can skew quota/cost reporting and API behavior.
+- Reduce operational risk (security defaults, logging noise, cache amplification).
+- Improve maintainability by breaking up large hot-path modules.
+
+### Non-goals (for this plan)
+- Rewriting provider business logic (e.g., full Antigravity provider redesign).
+- Changing external API contracts unless explicitly called out.
+- Replacing LiteLLM or FastAPI stack.
+
+### Success criteria (project-level)
+- ✅ No behavior regressions on existing endpoint compatibility.
+- ✅ Reduced p95 latency for streaming requests (target: 10–20% lower overhead in proxy layer).
+- ✅ Correct quota/token accounting for batched embeddings.
+- ✅ No event-loop stalls caused by synchronous file writes in hot paths.
+- ✅ Security-sensitive defaults are explicit and documented.
+
+---
+
+## 2) Current Findings Snapshot (from audit)
+
+### High-priority issues
+1. **Streaming wrapper always aggregates/parses chunks even when raw logging is off**  
+   - `src/proxy_app/main.py`
+2. **Embedding batch usage accounting likely overcounts**  
+   - `src/proxy_app/batch_manager.py`, `src/proxy_app/main.py`
+3. **`/v1/token-count` catches `HTTPException` and turns 400 into 500**  
+   - `src/proxy_app/main.py`
+4. **Sync I/O in async flows (startup + usage persistence path)**  
+   - `src/proxy_app/main.py`, `src/rotator_library/usage/persistence/storage.py`, `src/rotator_library/utils/resilient_io.py`
+5. **Cache miss path can spawn many background tasks + repeated disk reads**  
+   - `src/rotator_library/providers/provider_cache.py`
+
+### Important secondary issues
+- Model list cache has no TTL/invalidation (`src/rotator_library/client/rotating_client.py`).
+- Eager provider module import at startup (`src/rotator_library/providers/__init__.py`).
+- API key printed in cleartext on startup (`src/proxy_app/main.py`).
+- CORS/auth defaults should be made explicit and safer (`src/proxy_app/main.py`).
+- Very large modules/functions reduce maintainability (`src/proxy_app/main.py`, `src/rotator_library/providers/antigravity_provider.py`, etc.).
+
+---
+
+## 3) Scope and Workstreams
+
+## Workstream A — Correctness fixes (fastest ROI)
+
+### A1. Fix `/v1/token-count` exception handling
+**Files:**
+- `src/proxy_app/main.py`
+
+**Tasks**
+- [x] Add `except HTTPException: raise` before generic exception handling in `/v1/token-count`.
+- [x] Ensure malformed input returns 400, not 500.
+- [ ] Add endpoint tests for required fields and malformed payload behavior.
+
+**Validation**
+- [ ] Request missing `model` or `messages` returns HTTP 400.
+- [ ] Unexpected internal exception still returns HTTP 500.
+
+---
+
+### A2. Correct embedding batch usage aggregation
+**Files:**
+- `src/proxy_app/batch_manager.py`
+- `src/proxy_app/main.py`
+
+**Tasks**
+- [x] Define canonical usage behavior for split batch responses (shared total vs per-item allocation).
+- [x] Update batch worker to avoid attaching full batch usage to each per-item result.
+- [x] Update endpoint aggregation logic so total tokens are counted exactly once per batch.
+- [ ] Add tests for multi-input embedding requests (N>1) and verify usage totals.
+
+**Validation**
+- [x] For N-input requests, aggregated usage matches provider total (not N×).
+- [x] Existing response schema compatibility preserved.
+
+---
+
+### A3. Harmonize auth behavior across endpoint families
+**Files:**
+- `src/proxy_app/main.py`
+- `README.md`
+- `.env.example`
+
+**Tasks**
+- [x] Verified: Policy is open-mode when `PROXY_API_KEY` is unset (backward compatible).
+- [x] Verified: `verify_api_key` and `verify_anthropic_api_key` are consistent (both skip auth when PROXY_API_KEY is unset).
+- [ ] Document behavior clearly in README and env docs.
+
+**Validation**
+- [x] OpenAI and Anthropic endpoints behave identically under unset key mode.
+- [ ] Auth tests cover both configured and unset key scenarios.
+
+---
+
+## Workstream B — Hot-path performance optimizations
+
+### B1. Make streaming aggregation conditional
+**Files:**
+- `src/proxy_app/main.py`
+- `src/rotator_library/client/streaming.py` (reference)
+- `src/rotator_library/client/executor.py` (reference)
+
+**Tasks**
+- [x] Refactor `streaming_response_wrapper` to avoid accumulating/parsing all chunks when raw logging is disabled.
+- [x] Keep passthrough mode as lightweight as possible (yield directly; no chunk JSON parse unless needed).
+- [x] Preserve current behavior when raw logging is enabled.
+
+**Validation**
+- [ ] Streaming functionality unchanged for clients (including `[DONE]`).
+- [ ] Raw logging output remains complete when enabled.
+- [ ] Microbenchmark shows reduced overhead in no-raw-logging mode.
+
+---
+
+### B2. Add TTL + invalidation for model list cache
+**Files:**
+- `src/rotator_library/client/rotating_client.py`
+
+**Tasks**
+- [x] Replace simple provider→models dict cache with TTL-based cache entries.
+- [x] Add explicit invalidation hook (trigger on credential refresh/reload or endpoint action).
+- [x] Add config knobs for TTL duration.
+
+**Validation**
+- [ ] `/v1/models` updates after TTL expiry or explicit invalidation.
+- [ ] No additional errors in provider model discovery.
+
+---
+
+### B3. Prevent provider cache task amplification
+**Files:**
+- `src/rotator_library/providers/provider_cache.py`
+
+**Tasks**
+- [x] Add in-flight dedupe (singleflight) for disk fallback reads per cache key.
+- [x] Add bounded background lookup queue (via future wait with timeout).
+- [x] Avoid repeated full-file reads for concurrent misses of same key.
+
+**Validation**
+- [x] Concurrent misses for same key perform at most one disk retrieval operation in-flight.
+- [x] No unbounded growth in background tasks during synthetic miss storms.
+
+---
+
+## Workstream C — Async I/O and persistence resilience
+
+### C1. Remove event-loop blocking file operations in async paths
+**Files:**
+- `src/proxy_app/main.py`
+- `src/rotator_library/usage/persistence/storage.py`
+- `src/rotator_library/utils/resilient_io.py`
+
+**Tasks**
+- [x] Move startup metadata read/write in `lifespan` to non-blocking execution (`asyncio.to_thread` or async file API).
+- [x] Move usage serialization/write path off event loop where heavy (especially `save()` data assembly and disk write).
+- [x] Keep atomic-write semantics and failure buffering behavior intact.
+
+**Validation**
+- [ ] Under load, no long event-loop stalls attributable to file writes.
+- [ ] Usage files remain valid and recoverable after abrupt termination.
+
+---
+
+### C2. Tune save debounce and dirty-flush behavior
+**Files:**
+- `src/rotator_library/usage/manager.py`
+- `src/rotator_library/usage/persistence/storage.py`
+
+**Tasks**
+- [ ] Audit save frequency under high request volume.
+- [ ] Make debounce tunable via env/config with sensible defaults.
+- [ ] Ensure shutdown flush path preserves latest state.
+
+**Validation**
+- [ ] Reduced write frequency without losing correctness.
+- [ ] Dirty state flushed reliably on graceful shutdown.
+
+---
+
+## Workstream D — Security and operational hardening
+
+### D1. Mask startup key output
+**Files:**
+- `src/proxy_app/main.py`
+
+**Tasks**
+- [x] Replace full API key print with masked display (e.g., `sk-****abcd`).
+- [x] Keep a clear warning when key is unset.
+
+**Validation**
+- [x] No plaintext API secrets in startup logs.
+
+---
+
+### D2. Safer CORS defaults
+**Files:**
+- `src/proxy_app/main.py`
+- `.env.example`
+- `README.md`
+
+**Tasks**
+- [x] Replace wildcard CORS defaults with explicit env-driven allowlist.
+- [x] Ensure `allow_credentials` behavior is compatible with configured origins.
+- [x] Add migration note for users relying on permissive CORS.
+
+**Validation**
+- [ ] Browser clients operate correctly with configured origins.
+- [ ] Security posture improved by default.
+
+---
+
+### D3. Logging hygiene for hot paths
+**Files:**
+- `src/rotator_library/usage/manager.py`
+- `src/proxy_app/request_logger.py`
+
+**Tasks**
+- [x] Review high-frequency logs for DEBUG/INFO appropriateness.
+- [x] Verified: high-frequency paths already use DEBUG level.
+- [x] Verified: request logging is single-line per request (appropriate).
+
+**Validation**
+- [x] INFO logs are for significant events (initialization, warnings, errors).
+- [x] DEBUG logs available for troubleshooting without spamming production logs.
+
+---
+
+## Workstream E — Maintainability refactor (structural)
+
+### E1. Split proxy main module into cohesive units
+**Files (new + existing):**
+- `src/proxy_app/main.py` (refactored - slimmed to CLI/TUI only)
+- `src/proxy_app/app_factory.py` (new)
+- `src/proxy_app/dependencies.py` (new)
+- `src/proxy_app/routes/openai.py` (new)
+- `src/proxy_app/routes/anthropic.py` (new)
+- `src/proxy_app/routes/admin.py` (new)
+- `src/proxy_app/startup.py` (new)
+- `src/proxy_app/error_mapping.py` (new)
+- `src/proxy_app/streaming.py` (new)
+- `src/proxy_app/models.py` (new)
+
+**Tasks**
+- [x] Extract FastAPI setup + lifespan into factory/startup modules.
+- [x] Move endpoint handlers into route modules by concern.
+- [x] Centralize LiteLLM→HTTPException mapping to eliminate duplicated blocks.
+- [x] Keep CLI/TUI launch behavior unchanged.
+
+**New Module Structure:**
+```
+proxy_app/
+├── main.py              # CLI/TUI entry point only (~240 lines, was ~1700)
+├── app_factory.py       # create_app() factory
+├── startup.py           # lifespan + initialization logic
+├── dependencies.py      # FastAPI dependencies (auth, state access)
+├── models.py            # Pydantic request/response models
+├── streaming.py         # streaming_response_wrapper
+├── error_mapping.py     # Centralized LiteLLM→HTTPException mapping
+└── routes/
+    ├── openai.py        # /v1/chat/completions, /v1/embeddings, etc.
+    ├── anthropic.py     # /v1/messages, /v1/messages/count_tokens
+    └── admin.py         # /v1/quota-stats, /v1/providers, etc.
+```
+
+**Validation**
+- [x] All existing endpoints preserved.
+- [x] Smaller files/functions; easier code navigation.
+- [x] No startup or import regressions (all files compile).
+
+---
+
+### E2. Reduce complexity in usage stats/reporting path
+**Files:**
+- `src/rotator_library/usage/manager.py`
+
+**Tasks**
+- [ ] Extract `get_stats_for_endpoint()` formatting/aggregation into helper module(s).
+- [ ] Separate calculation logic from presentation shaping.
+- [ ] Add focused unit tests for stats aggregation.
+
+**Validation**
+- [ ] Endpoint output unchanged (unless intentional fixes are documented).
+- [ ] Complexity and function size reduced.
+
+---
+
+### E3. Provider plugin import optimization (optional in this cycle)
+**Files:**
+- `src/rotator_library/providers/__init__.py`
+
+**Tasks**
+- [ ] Evaluate lazy plugin import registry (name→module path mapping).
+- [ ] Load provider module on first use rather than full eager import.
+- [ ] Validate startup-time improvements and no plugin discovery regressions.
+
+**Validation**
+- [ ] Cold-start time improves measurably.
+- [ ] Provider feature parity maintained.
+
+---
+
+## Workstream F — Test, benchmark, and release safeguards
+
+### F1. Expand automated coverage around changed behavior
+**Files:**
+- `tests/` (new test modules)
+- Existing test fixtures as needed
+
+**Tasks**
+- [ ] Add tests for `/v1/token-count` error mapping.
+- [ ] Add tests for embedding batching usage accounting.
+- [ ] Add tests for streaming wrapper passthrough vs logging mode.
+- [ ] Add tests for auth parity between OpenAI/Anthropic endpoints.
+- [ ] Add tests for provider cache miss dedupe behavior.
+
+**Validation**
+- [ ] CI green with new tests.
+- [ ] Regression tests reproduce and prevent prior bugs.
+
+---
+
+### F2. Add lightweight performance regression checks
+**Files (new):**
+- `tests/perf/test_streaming_overhead.py` (or scripts under `scripts/`)
+- `tests/perf/test_cache_miss_storm.py`
+
+**Tasks**
+- [ ] Build reproducible microbench for streaming wrapper overhead.
+- [ ] Simulate cache miss storm and measure background task growth.
+- [ ] Record baseline + post-change metrics in PR notes.
+
+**Validation**
+- [ ] Measurable improvements captured and repeatable.
+
+---
+
+### F3. Dependency separation for runtime image size and clarity
+**Files:**
+- `requirements.txt`
+- `requirements-dev.txt`
+- `Dockerfile`
+
+**Tasks**
+- [ ] Move test/build-only deps out of runtime requirements.
+- [ ] Ensure Docker runtime installs only runtime deps.
+- [ ] Keep dev workflow intact via dev requirements.
+
+**Validation**
+- [ ] Smaller runtime image.
+- [ ] Tests still runnable in dev environment.
+
+---
+
+## 4) Implementation Order / Milestones
+
+| Milestone | Scope | Risk | Status | Dependency |
+|---|---|---:|:---:|---|
+| M1 | A1, A2 | Low | **✅ Complete** | None |
+| M2 | B1, D1 | Low | **✅ Complete** | M1 recommended |
+| M3 | C1 (startup I/O), D2, D3 | Medium | **✅ Complete** | M2 |
+| M4 | B3, B2 | Medium | **✅ Complete** | M2 |
+| M5 | E1 full module decomposition | Medium/High | **✅ Complete** | M1–M4 |
+| M6 | E2, F1, F2, F3 | Medium | ⏳ Backlog | M1–M5 |
+| M7 | E3 (optional lazy imports) | Medium | ⏳ Backlog | M5 |
+
+---
+
+## 5) Detailed Validation Plan
+
+### Functional checks
+- [ ] OpenAI chat/completions streaming and non-streaming behavior unchanged.
+- [ ] Anthropic `/v1/messages` and `/v1/messages/count_tokens` behavior unchanged except planned auth consistency.
+- [ ] Embedding multi-input responses have correct usage totals.
+- [ ] `/v1/token-count` returns correct status codes for client errors.
+
+### Performance checks
+- [ ] Compare p50/p95 latency for streaming requests before/after B1.
+- [ ] Compare CPU and memory during sustained streaming load.
+- [ ] Run cache miss storm scenario before/after B3; verify bounded task count.
+
+### Reliability checks
+- [ ] Restart proxy during active writes; verify persisted usage integrity.
+- [ ] Simulate write failures and validate resilient writer behavior remains intact.
+
+### Security checks
+- [ ] No plaintext API key in logs/startup output.
+- [ ] CORS behavior verified for allowed/denied origins.
+
+---
+
+## 6) Rollout and Risk Management
+
+### Feature-flag style toggles (recommended)
+- [ ] Add/retain env toggles for new behaviors where risk exists:
+  - streaming lightweight mode (default ON)
+  - cache singleflight (default ON)
+  - strict auth mode (configurable)
+  - CORS allowlist enforcement (default secure)
+
+### Rollout strategy
+- [ ] Land M1 + M2 first (low-risk/high-confidence).
+- [ ] Ship M3/M4 behind conservative defaults if needed.
+- [ ] Execute E1 structural refactor in small PR slices (routes first, then startup/dependencies).
+
+### Rollback strategy
+- [ ] Keep PRs scoped by milestone so each can be reverted independently.
+- [ ] Preserve old behavior behind temporary compatibility toggles for 1–2 releases.
+
+---
+
+## 7) Proposed PR Breakdown
+
+### PR-1: Correctness hotfixes
+- [ ] Token-count status code fix
+- [ ] Embedding usage aggregation fix
+- [ ] Tests for both
+
+### PR-2: Streaming + secret masking
+- [ ] Conditional streaming aggregation
+- [ ] API key masking on startup
+- [ ] Streaming tests/microbench
+
+### PR-3: Async I/O hardening + CORS/auth policy cleanup
+- [ ] Non-blocking startup/persistence file operations
+- [ ] Auth consistency
+- [ ] CORS config via env
+
+### PR-4: Cache and model-list cache improvements
+- [ ] ProviderCache miss dedupe/singleflight
+- [ ] Model list cache TTL/invalidation
+
+### PR-5+: Structural refactors
+- [ ] Main module decomposition
+- [ ] Usage stats extraction
+- [ ] Optional lazy provider imports
+
+---
+
+## 8) Commands and Tooling Checklist
+
+```bash
+# Setup
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+
+# Tests
+pytest -q
+
+# Focused tests (example naming)
+pytest -q tests/test_token_count_endpoint.py
+pytest -q tests/test_embeddings_batch_usage.py
+pytest -q tests/test_streaming_wrapper.py
+
+# Run proxy locally
+python src/proxy_app/main.py --host 127.0.0.1 --port 8000
+```
+
+---
+
+## 9) File Reference Index
+
+### Core files in scope
+- `src/proxy_app/main.py`
+- `src/proxy_app/batch_manager.py`
+- `src/proxy_app/request_logger.py`
+- `src/rotator_library/client/rotating_client.py`
+- `src/rotator_library/client/executor.py`
+- `src/rotator_library/client/streaming.py`
+- `src/rotator_library/usage/manager.py`
+- `src/rotator_library/usage/persistence/storage.py`
+- `src/rotator_library/providers/provider_cache.py`
+- `src/rotator_library/utils/resilient_io.py`
+- `src/rotator_library/providers/__init__.py`
+- `requirements.txt`
+- `requirements-dev.txt`
+- `Dockerfile`
+- `README.md`
+- `.env.example`
+
+### New files expected (refactor phase)
+- `src/proxy_app/app_factory.py`
+- `src/proxy_app/dependencies.py`
+- `src/proxy_app/startup.py`
+- `src/proxy_app/error_mapping.py`
+- `src/proxy_app/routes/openai.py`
+- `src/proxy_app/routes/anthropic.py`
+- `src/proxy_app/routes/admin.py`
+- `tests/test_token_count_endpoint.py`
+- `tests/test_embeddings_batch_usage.py`
+- `tests/test_streaming_wrapper.py`
+- `tests/test_auth_parity.py`
+- `tests/test_provider_cache_singleflight.py`
+
+---
+
+## 10) External References (upstream libraries / behavior)
+
+- FastAPI repository: https://github.com/fastapi/fastapi
+- Starlette repository (CORS middleware behavior): https://github.com/encode/starlette
+- Uvicorn repository: https://github.com/encode/uvicorn
+- HTTPX repository: https://github.com/encode/httpx
+- LiteLLM repository: https://github.com/BerriAI/litellm
+
+---
+
+## 11) Definition of Done (overall)
+
+- [x] Milestones M1–M4 complete and merged.
+- [ ] Structural refactor milestones (M5-M7) pending - requires breaking up main.py.
+- [ ] Added tests pass in CI and locally.
+- [ ] Performance + reliability improvements documented with before/after numbers.
+- [x] Security-sensitive logging/CORS/auth defaults documented and validated.
+
+### Implementation Summary
+
+**Completed Workstreams:**
+
+| Workstream | Key Changes |
+|------------|-------------|
+| **A - Correctness** | Fixed token-count 400→500 bug; Fixed embedding batch usage overcounting (N×→1×) |
+| **B - Performance** | Streaming passthrough mode (no JSON parse when raw logging off); Model list cache TTL + invalidation; Provider cache singleflight for concurrent disk lookups |
+| **C - Async I/O** | Non-blocking file I/O in lifespan (credential metadata); Usage storage now uses `asyncio.to_thread()` |
+| **D - Security** | API key masking in startup logs (`sk-****abcd`); CORS env configuration (`PROXY_CORS_ORIGINS`, `PROXY_CORS_CREDENTIALS`); Logging hygiene verified |
+| **E - Maintainability** | Full module decomposition: main.py slimmed from ~1700 to ~240 lines; routes organized by concern; centralized error mapping |
+
+**Files Modified/Created:**
+
+| File | Status | Description |
+|------|--------|-------------|
+| `src/proxy_app/main.py` | Modified | Slimmed to CLI/TUI only (~240 lines, was ~1700) |
+| `src/proxy_app/app_factory.py` | **New** | FastAPI application factory |
+| `src/proxy_app/startup.py` | **New** | Lifespan context + initialization logic |
+| `src/proxy_app/dependencies.py` | **New** | FastAPI dependencies (auth, state) |
+| `src/proxy_app/models.py` | **New** | Pydantic request/response models |
+| `src/proxy_app/streaming.py` | **New** | Streaming response wrapper |
+| `src/proxy_app/error_mapping.py` | **New** | Centralized LiteLLM→HTTPException mapping |
+| `src/proxy_app/routes/openai.py` | **New** | OpenAI-compatible endpoints |
+| `src/proxy_app/routes/anthropic.py` | **New** | Anthropic-compatible endpoints |
+| `src/proxy_app/routes/admin.py` | **New** | Admin/quota endpoints |
+| `src/proxy_app/batch_manager.py` | Modified | Embedding usage aggregation fix |
+| `src/rotator_library/usage/persistence/storage.py` | Modified | Async file I/O |
+| `src/rotator_library/providers/provider_cache.py` | Modified | Singleflight for disk lookups |
+| `src/rotator_library/client/rotating_client.py` | Modified | TTL-based model list cache |
+| `.env.example` | Modified | New CORS and cache TTL documentation |
+
+### Lines of Code Comparison
+
+| Module | Before | After | Reduction |
+|--------|--------|-------|-----------|
+| main.py | ~1,700 | ~240 | **86%** |
+| Total proxy_app | ~1,700 | ~2,400* | Organized into 10 focused files |
+
+*New files are more maintainable with single responsibilities

--- a/README.md
+++ b/README.md
@@ -784,6 +784,7 @@ Imported credentials are normalized and stored locally as:
 **Features:**
 
 - OAuth Authorization Code + PKCE
+- Uses OpenAI's public Codex OAuth client ID (non-secret by OAuth design)
 - Automatic refresh + re-auth queueing
 - File-based and stateless env credentials (`env://openai_codex/N`)
 - Sequential rotation by default (`ROTATION_MODE_OPENAI_CODEX=sequential`)

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,23 @@
+## Plan Review Summary
+The plan is highly feasible, exceptionally well-structured, and accurately reflects the current state of the codebase. The identified issues—such as the synchronous I/O blocks in `src/proxy_app/main.py` lifespan and `src/rotator_library/usage/persistence/storage.py`, the `HTTPException` swallowing in `/v1/token-count`, the O(N) cache miss amplification in `ProviderCache`, and the embedding batch usage overcounting—are all verified present in the codebase. The phased rollout strategy (M1-M7) and feature flag recommendations provide a safe path for implementation without risking endpoint regressions.
+
+## Critical Issues
+*None found in the plan itself.* The plan correctly identifies critical issues in the codebase and proposes sound solutions.
+
+## Important Issues
+- **`asyncio.to_thread` usage (C1):** In `src/rotator_library/utils/resilient_io.py`, the `_writer.write()` method uses a synchronous `flock` and standard `open()`. When migrating the `save()` method in `storage.py` off the event loop, simply wrapping `self._writer.write(data)` in `asyncio.to_thread()` is the safest approach without needing to rewrite the resilient disk I/O library to be natively async. The plan mentions this, but it's worth emphasizing to prevent scope creep.
+
+## Suggestions
+- **FastAPI CORS default migration (D2):** When shifting from `allow_origins=["*"]` to an explicit allowlist in `src/proxy_app/main.py`, ensure that `http://localhost:*` and `http://127.0.0.1:*` are included in the default fallback if the environment variable is not explicitly set. This prevents breaking local UI/TUI developer workflows out of the box.
+- **Dependency Separation (F3):** When splitting `requirements.txt` into runtime and dev dependencies, be careful not to remove `rich` or `prompt_toolkit` from runtime if they are used by the CLI/TUI entry points (which they appear to be in `main.py` onboarding).
+
+## Codebase Alignment
+- **A1 (`/v1/token-count` fix):** -> Aligns perfectly with `src/proxy_app/main.py:1497-1520` (exception block catches `HTTPException` and re-raises as 500).
+- **A2 (Embedding usage):** -> Aligns perfectly with `src/proxy_app/batch_manager.py` (usage object is attached to every single batch item unconditionally).
+- **B1 (Streaming wrapper):** -> Aligns perfectly with `src/proxy_app/main.py:717` (`streaming_response_wrapper` builds `response_chunks` regardless of logging mode).
+- **B3 (ProviderCache amplification):** -> Aligns perfectly with `src/rotator_library/providers/provider_cache.py:382` (spawns un-deduplicated `_check_disk_fallback` tasks on every miss).
+- **C1 (Async I/O):** -> Aligns perfectly with `main.py`'s `lifespan` function (sync `json.load`) and `storage.py`'s `save` function (sync `write()`).
+- **D1/D2 (Security defaults):** -> Aligns perfectly; API key is printed plaintext at `main.py:96`, and CORS uses `["*"]` with `allow_credentials=True` at `main.py:666`.
+
+## Approval Status
+**READY TO IMPLEMENT**

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-asyncio
+respx

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,8 @@ customtkinter
 
 # For building the executable
 pyinstaller
+
+# Test dependencies
+pytest
+pytest-asyncio
+respx

--- a/src/proxy_app/app_factory.py
+++ b/src/proxy_app/app_factory.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Mirrowel
+
+"""
+FastAPI application factory.
+
+This module provides the create_app() function for creating and configuring
+the FastAPI application instance.
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from proxy_app.startup import lifespan
+
+
+def create_app(data_dir: Optional[Path] = None) -> FastAPI:
+    """
+    Create and configure the FastAPI application.
+
+    Args:
+        data_dir: Optional data directory path
+
+    Returns:
+        Configured FastAPI application instance
+    """
+    # Create app with lifespan
+    app = FastAPI(
+        title="LLM API Key Proxy",
+        description="A proxy server for LLM API key rotation and management",
+        version="1.0.0",
+        lifespan=lambda app: lifespan(app, data_dir),
+    )
+
+    # Configure CORS
+    _configure_cors(app)
+
+    # Register routes
+    _register_routes(app)
+
+    return app
+
+
+def _configure_cors(app: FastAPI) -> None:
+    """Configure CORS middleware from environment variables."""
+    # PROXY_CORS_ORIGINS: comma-separated list or "*" for all
+    _cors_origins_env = os.getenv("PROXY_CORS_ORIGINS", "*")
+    _cors_origins = [origin.strip() for origin in _cors_origins_env.split(",") if origin.strip()]
+    _cors_credentials = os.getenv("PROXY_CORS_CREDENTIALS", "false").lower() == "true"
+
+    # Security warnings
+    if _cors_origins == ["*"]:
+        logging.warning(
+            "CORS is configured to allow all origins (*). "
+            "Set PROXY_CORS_ORIGINS to a specific domain list for production."
+        )
+    if _cors_credentials and _cors_origins == ["*"]:
+        logging.warning(
+            "CORS allow_credentials is enabled with wildcard origins. "
+            "Browsers reject this combination. Set explicit PROXY_CORS_ORIGINS."
+        )
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=_cors_origins,
+        allow_credentials=_cors_credentials,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+
+def _register_routes(app: FastAPI) -> None:
+    """Register all API routes."""
+    from proxy_app.routes import openai, anthropic, admin
+
+    # OpenAI-compatible routes
+    app.include_router(openai.router)
+
+    # Anthropic-compatible routes
+    app.include_router(anthropic.router)
+
+    # Admin routes
+    app.include_router(admin.router)

--- a/src/proxy_app/batch_manager.py
+++ b/src/proxy_app/batch_manager.py
@@ -45,11 +45,12 @@ class EmbeddingBatcher:
                 # Distribute results back to the original requesters
                 for i, future in enumerate(futures):
                     # Create a new response object for each item in the batch
+                    # Usage is attached only to the first result; caller must extract it once
                     single_response_data = {
                         "object": response.object,
                         "model": response.model,
                         "data": [response.data[i]],
-                        "usage": response.usage # Usage is for the whole batch
+                        "usage": response.usage if i == 0 else None
                     }
                     future.set_result(single_response_data)
 

--- a/src/proxy_app/dependencies.py
+++ b/src/proxy_app/dependencies.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Mirrowel
+
+"""
+FastAPI dependencies for the proxy application.
+
+This module centralizes all FastAPI dependency functions including:
+- Credential retrieval from app state
+- API key verification for OpenAI and Anthropic endpoints
+"""
+
+import os
+from typing import Optional
+
+from fastapi import Request, HTTPException, Depends
+from fastapi.security import APIKeyHeader
+
+from rotator_library import RotatingClient
+from proxy_app.batch_manager import EmbeddingBatcher
+
+# Configuration
+PROXY_API_KEY = os.getenv("PROXY_API_KEY")
+
+# Security schemes
+api_key_header = APIKeyHeader(name="Authorization", auto_error=False)
+anthropic_api_key_header = APIKeyHeader(name="x-api-key", auto_error=False)
+
+
+def get_rotating_client(request: Request) -> RotatingClient:
+    """Dependency to get the rotating client instance from the app state."""
+    return request.app.state.rotating_client
+
+
+def get_embedding_batcher(request: Request) -> Optional[EmbeddingBatcher]:
+    """Dependency to get the embedding batcher instance from the app state."""
+    return getattr(request.app.state, "embedding_batcher", None)
+
+
+def get_model_info_service(request: Request):
+    """Dependency to get the model info service from the app state."""
+    return getattr(request.app.state, "model_info_service", None)
+
+
+async def verify_api_key(auth: str = Depends(api_key_header)):
+    """
+    Dependency to verify the proxy API key for OpenAI-compatible endpoints.
+
+    If PROXY_API_KEY is not set, skips verification (open access mode).
+    Accepts Bearer token in Authorization header.
+    """
+    # If PROXY_API_KEY is not set or empty, skip verification (open access)
+    if not PROXY_API_KEY:
+        return auth
+    if not auth or auth != f"Bearer {PROXY_API_KEY}":
+        raise HTTPException(status_code=401, detail="Invalid or missing API Key")
+    return auth
+
+
+async def verify_anthropic_api_key(
+    x_api_key: str = Depends(anthropic_api_key_header),
+    auth: str = Depends(api_key_header),
+):
+    """
+    Dependency to verify API key for Anthropic endpoints.
+
+    Accepts either x-api-key header (Anthropic style) or Authorization Bearer (OpenAI style).
+    If PROXY_API_KEY is not set, skips verification (open access mode).
+    """
+    # Check x-api-key first (Anthropic style)
+    if x_api_key and x_api_key == PROXY_API_KEY:
+        return x_api_key
+    # Fall back to Bearer token (OpenAI style)
+    if auth and auth == f"Bearer {PROXY_API_KEY}":
+        return auth
+    # If PROXY_API_KEY is not set, skip verification (open access)
+    if not PROXY_API_KEY:
+        return x_api_key or auth
+    raise HTTPException(status_code=401, detail="Invalid or missing API Key")
+
+
+def require_api_key():
+    """Factory for API key dependency - always requires key (strict mode)."""
+    if not PROXY_API_KEY:
+        raise HTTPException(
+            status_code=500,
+            detail="PROXY_API_KEY must be configured for this endpoint"
+        )
+    return Depends(verify_api_key)

--- a/src/proxy_app/error_mapping.py
+++ b/src/proxy_app/error_mapping.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Mirrowel
+
+"""
+Centralized error mapping from LiteLLM exceptions to FastAPI HTTPExceptions.
+
+This module eliminates duplicated exception handling blocks across endpoints
+by providing a single mapping function for LiteLLM errors.
+"""
+
+from fastapi import HTTPException
+from typing import Optional, Dict, Any
+import litellm
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def map_litellm_error(e: Exception, context: Optional[str] = None) -> HTTPException:
+    """
+    Map a LiteLLM exception to an appropriate HTTPException.
+
+    Args:
+        e: The exception from LiteLLM or related libraries
+        context: Optional context string for logging (e.g., endpoint name)
+
+    Returns:
+        HTTPException with appropriate status code and detail
+    """
+    ctx = f" ({context})" if context else ""
+
+    # Map specific LiteLLM error types to HTTP status codes
+    if isinstance(e, litellm.InvalidRequestError):
+        return HTTPException(status_code=400, detail=f"Invalid Request: {str(e)}")
+
+    if isinstance(e, ValueError):
+        return HTTPException(status_code=400, detail=f"Invalid Request: {str(e)}")
+
+    if isinstance(e, litellm.ContextWindowExceededError):
+        return HTTPException(status_code=400, detail=f"Context Window Exceeded: {str(e)}")
+
+    if isinstance(e, litellm.AuthenticationError):
+        return HTTPException(status_code=401, detail=f"Authentication Error: {str(e)}")
+
+    if isinstance(e, litellm.RateLimitError):
+        return HTTPException(status_code=429, detail=f"Rate Limit Exceeded: {str(e)}")
+
+    if isinstance(e, litellm.ServiceUnavailableError):
+        return HTTPException(status_code=503, detail=f"Service Unavailable: {str(e)}")
+
+    if isinstance(e, litellm.APIConnectionError):
+        return HTTPException(status_code=503, detail=f"Service Unavailable: {str(e)}")
+
+    if isinstance(e, litellm.Timeout):
+        return HTTPException(status_code=504, detail=f"Gateway Timeout: {str(e)}")
+
+    if isinstance(e, litellm.InternalServerError):
+        return HTTPException(status_code=502, detail=f"Bad Gateway: {str(e)}")
+
+    if isinstance(e, litellm.OpenAIError):
+        return HTTPException(status_code=502, detail=f"Bad Gateway: {str(e)}")
+
+    # Log unexpected errors
+    logger.error(f"Unhandled exception{ctx}: {e}")
+    return HTTPException(status_code=500, detail=str(e))
+
+
+def create_anthropic_error_response(
+    error_type: str, message: str, status_code: int
+) -> Dict[str, Any]:
+    """
+    Create an Anthropic-compatible error response structure.
+
+    Args:
+        error_type: The error type string (e.g., 'invalid_request_error')
+        message: The error message
+        status_code: The HTTP status code
+
+    Returns:
+        Dict with Anthropic error format
+    """
+    return {
+        "type": "error",
+        "error": {"type": error_type, "message": message},
+    }
+
+
+def map_litellm_error_to_anthropic(
+    e: Exception, context: Optional[str] = None
+) -> HTTPException:
+    """
+    Map a LiteLLM exception to an Anthropic-compatible HTTPException.
+
+    Args:
+        e: The exception from LiteLLM or related libraries
+        context: Optional context string for logging
+
+    Returns:
+        HTTPException with Anthropic-formatted error detail
+    """
+    ctx = f" ({context})" if context else ""
+
+    error_response = None
+    status_code = 500
+
+    if isinstance(e, (litellm.InvalidRequestError, ValueError, litellm.ContextWindowExceededError)):
+        error_response = create_anthropic_error_response(
+            "invalid_request_error", str(e), 400
+        )
+        status_code = 400
+    elif isinstance(e, litellm.AuthenticationError):
+        error_response = create_anthropic_error_response(
+            "authentication_error", str(e), 401
+        )
+        status_code = 401
+    elif isinstance(e, litellm.RateLimitError):
+        error_response = create_anthropic_error_response(
+            "rate_limit_error", str(e), 429
+        )
+        status_code = 429
+    elif isinstance(e, (litellm.ServiceUnavailableError, litellm.APIConnectionError)):
+        error_response = create_anthropic_error_response("api_error", str(e), 503)
+        status_code = 503
+    elif isinstance(e, litellm.Timeout):
+        error_response = create_anthropic_error_response(
+            "api_error", f"Request timed out: {str(e)}", 504
+        )
+        status_code = 504
+    else:
+        # Default to api_error for unhandled exceptions
+        logger.error(f"Unhandled exception in Anthropic endpoint{ctx}: {e}")
+        error_response = create_anthropic_error_response("api_error", str(e), 500)
+        status_code = 500
+
+    return HTTPException(status_code=status_code, detail=error_response)
+
+
+class ErrorMappingHelper:
+    """
+    Helper class for endpoints to handle common error patterns.
+
+    Usage:
+        error_helper = ErrorMappingHelper("chat_completions")
+        try:
+            ...
+        except Exception as e:
+            raise error_helper.handle_error(e)
+    """
+
+    def __init__(self, endpoint_name: str, mode: str = "openai"):
+        """
+        Initialize error mapping helper.
+
+        Args:
+            endpoint_name: Name of the endpoint for logging context
+            mode: 'openai' or 'anthropic' error format
+        """
+        self.endpoint_name = endpoint_name
+        self.mode = mode
+
+    def handle_error(self, e: Exception) -> HTTPException:
+        """Map exception to appropriate HTTPException."""
+        if self.mode == "anthropic":
+            return map_litellm_error_to_anthropic(e, self.endpoint_name)
+        return map_litellm_error(e, self.endpoint_name)

--- a/src/proxy_app/launcher_tui.py
+++ b/src/proxy_app/launcher_tui.py
@@ -190,6 +190,7 @@ class SettingsDetector:
             "antigravity": "ANTIGRAVITY",
             "qwen_code": "QWEN_CODE",
             "iflow": "IFLOW",
+            "openai_codex": "OPENAI_CODEX",
         }
 
         for provider, env_prefix in env_oauth_providers.items():

--- a/src/proxy_app/main.py
+++ b/src/proxy_app/main.py
@@ -1,11 +1,19 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Mirrowel
 
-import time
-import uuid
+"""
+LLM API Key Proxy - Main entry point.
 
-# Phase 1: Minimal imports for arg parsing and TUI
-import asyncio
+This module handles:
+- CLI argument parsing
+- TUI launcher mode
+- Credential tool mode
+- Application startup
+
+The actual FastAPI application is created via app_factory.create_app().
+"""
+
+import time
 import os
 from pathlib import Path
 import sys
@@ -44,50 +52,52 @@ if len(sys.argv) == 1:
     from proxy_app.launcher_tui import run_launcher_tui
 
     run_launcher_tui()
-    # Launcher modifies sys.argv and returns, or exits if user chose Exit
-    # If we get here, user chose "Run Proxy" and sys.argv is modified
     # Re-parse arguments with modified sys.argv
     args = parser.parse_args()
 
-# Check if credential tool mode (also doesn't need heavy proxy imports)
+# Check if credential tool mode
 if args.add_credential:
     from rotator_library.credential_tool import run_credential_tool
 
     run_credential_tool()
     sys.exit(0)
 
-# If we get here, we're ACTUALLY running the proxy - NOW show startup messages and start timer
+# If we get here, we're ACTUALLY running the proxy
 _start_time = time.time()
 
-# Load all .env files from root folder (main .env first, then any additional *.env files)
+# Load environment variables
 from dotenv import load_dotenv
-from glob import glob
 
-# Get the application root directory (EXE dir if frozen, else CWD)
-# Inlined here to avoid triggering heavy rotator_library imports before loading screen
 if getattr(sys, "frozen", False):
     _root_dir = Path(sys.executable).parent
 else:
     _root_dir = Path.cwd()
 
-# Load main .env first
 load_dotenv(_root_dir / ".env")
 
-# Load any additional .env files (e.g., antigravity_all_combined.env, gemini_cli_all_combined.env)
+# Load additional .env files
 _env_files_found = list(_root_dir.glob("*.env"))
 for _env_file in sorted(_root_dir.glob("*.env")):
-    if _env_file.name != ".env":  # Skip main .env (already loaded)
-        load_dotenv(_env_file, override=False)  # Don't override existing values
+    if _env_file.name != ".env":
+        load_dotenv(_env_file, override=False)
 
-# Log discovered .env files for deployment verification
 if _env_files_found:
     _env_names = [_ef.name for _ef in _env_files_found]
     print(f"📁 Loaded {len(_env_files_found)} .env file(s): {', '.join(_env_names)}")
 
 # Get proxy API key for display
 proxy_api_key = os.getenv("PROXY_API_KEY")
+
+
+def _mask_api_key(key: str) -> str:
+    """Mask API key for safe display in logs. Shows first 4 and last 4 chars."""
+    if not key or len(key) <= 8:
+        return "****"
+    return f"{key[:4]}****{key[-4:]}"
+
+
 if proxy_api_key:
-    key_display = f"✓ {proxy_api_key}"
+    key_display = f"✓ {_mask_api_key(proxy_api_key)}"
 else:
     key_display = "✗ Not Set (INSECURE - anyone can access!)"
 
@@ -98,8 +108,7 @@ print(f"GitHub: https://github.com/Mirrowel/LLM-API-Key-Proxy")
 print("━" * 70)
 print("Loading server components...")
 
-
-# Phase 2: Load Rich for loading spinner (lightweight)
+# Phase 2: Load Rich for loading spinner
 from rich.console import Console
 
 _console = Console()
@@ -107,162 +116,38 @@ _console = Console()
 # Phase 3: Heavy dependencies with granular loading messages
 print("  → Loading FastAPI framework...")
 with _console.status("[dim]Loading FastAPI framework...", spinner="dots"):
-    from contextlib import asynccontextmanager
-    from fastapi import FastAPI, Request, HTTPException, Depends
-    from fastapi.middleware.cors import CORSMiddleware
-    from fastapi.responses import StreamingResponse, JSONResponse
-    from fastapi.security import APIKeyHeader
+    import litellm
 
 print("  → Loading core dependencies...")
 with _console.status("[dim]Loading core dependencies...", spinner="dots"):
-    from dotenv import load_dotenv
-    import colorlog
-    import json
-    from typing import AsyncGenerator, Any, List, Optional, Union
-    from pydantic import BaseModel, ConfigDict, Field
+    from rotator_library.utils.paths import get_logs_dir, get_data_file
 
-    # --- Early Log Level Configuration ---
-    logging.getLogger("LiteLLM").setLevel(logging.WARNING)
-
-print("  → Loading LiteLLM library...")
-with _console.status("[dim]Loading LiteLLM library...", spinner="dots"):
-    import litellm
-
-# Phase 4: Application imports with granular loading messages
 print("  → Initializing proxy core...")
 with _console.status("[dim]Initializing proxy core...", spinner="dots"):
-    from rotator_library import RotatingClient
-    from rotator_library.credential_manager import CredentialManager
-    from rotator_library.background_refresher import BackgroundRefresher
-    from rotator_library.model_info_service import init_model_info_service
-    from proxy_app.request_logger import log_request_to_console
-    from proxy_app.batch_manager import EmbeddingBatcher
-    from proxy_app.detailed_logger import RawIOLogger
+    from proxy_app.app_factory import create_app
+    from proxy_app.startup import _discover_api_keys
 
-print("  → Discovering provider plugins...")
-# Provider lazy loading happens during import, so time it here
-_provider_start = time.time()
-with _console.status("[dim]Discovering provider plugins...", spinner="dots"):
-    from rotator_library import (
-        PROVIDER_PLUGINS,
-    )  # This triggers lazy load via __getattr__
-_provider_time = time.time() - _provider_start
-
-# Get count after import (without timing to avoid double-counting)
-_plugin_count = len(PROVIDER_PLUGINS)
-
-
-# --- Pydantic Models ---
-class EmbeddingRequest(BaseModel):
-    model: str
-    input: Union[str, List[str]]
-    input_type: Optional[str] = None
-    dimensions: Optional[int] = None
-    user: Optional[str] = None
-
-
-class ModelCard(BaseModel):
-    """Basic model card for minimal response."""
-
-    id: str
-    object: str = "model"
-    created: int = Field(default_factory=lambda: int(time.time()))
-    owned_by: str = "Mirro-Proxy"
-
-
-class ModelCapabilities(BaseModel):
-    """Model capability flags."""
-
-    tool_choice: bool = False
-    function_calling: bool = False
-    reasoning: bool = False
-    vision: bool = False
-    system_messages: bool = True
-    prompt_caching: bool = False
-    assistant_prefill: bool = False
-
-
-class EnrichedModelCard(BaseModel):
-    """Extended model card with pricing and capabilities."""
-
-    id: str
-    object: str = "model"
-    created: int = Field(default_factory=lambda: int(time.time()))
-    owned_by: str = "unknown"
-    # Pricing (optional - may not be available for all models)
-    input_cost_per_token: Optional[float] = None
-    output_cost_per_token: Optional[float] = None
-    cache_read_input_token_cost: Optional[float] = None
-    cache_creation_input_token_cost: Optional[float] = None
-    # Limits (optional)
-    max_input_tokens: Optional[int] = None
-    max_output_tokens: Optional[int] = None
-    context_window: Optional[int] = None
-    # Capabilities
-    mode: str = "chat"
-    supported_modalities: List[str] = Field(default_factory=lambda: ["text"])
-    supported_output_modalities: List[str] = Field(default_factory=lambda: ["text"])
-    capabilities: Optional[ModelCapabilities] = None
-    # Debug info (optional)
-    _sources: Optional[List[str]] = None
-    _match_type: Optional[str] = None
-
-    model_config = ConfigDict(extra="allow")  # Allow extra fields from the service
-
-
-class ModelList(BaseModel):
-    """List of models response."""
-
-    object: str = "list"
-    data: List[ModelCard]
-
-
-class EnrichedModelList(BaseModel):
-    """List of enriched models with pricing and capabilities."""
-
-    object: str = "list"
-    data: List[EnrichedModelCard]
-
-
-# --- Anthropic API Models (imported from library) ---
-from rotator_library.anthropic_compat import (
-    AnthropicMessagesRequest,
-    AnthropicCountTokensRequest,
-)
-
-
-# Calculate total loading time
+# Calculate loading time
 _elapsed = time.time() - _start_time
-print(
-    f"✓ Server ready in {_elapsed:.2f}s ({_plugin_count} providers discovered in {_provider_time:.2f}s)"
-)
+print(f"✓ Server ready in {_elapsed:.2f}s")
 
-# Clear screen and reprint header for clean startup view
-# This pushes loading messages up (still in scroll history) but shows a clean final screen
+# Clear screen and reprint header
 import os as _os_module
-
 _os_module.system("cls" if _os_module.name == "nt" else "clear")
 
-# Reprint header
 print("━" * 70)
 print(f"Starting proxy on {args.host}:{args.port}")
 print(f"Proxy API Key: {key_display}")
 print(f"GitHub: https://github.com/Mirrowel/LLM-API-Key-Proxy")
 print("━" * 70)
-print(
-    f"✓ Server ready in {_elapsed:.2f}s ({_plugin_count} providers discovered in {_provider_time:.2f}s)"
-)
-
-
-# Note: Debug logging will be added after logging configuration below
+print(f"✓ Server ready in {_elapsed:.2f}s")
 
 # --- Logging Configuration ---
-# Import path utilities here (after loading screen) to avoid triggering heavy imports early
-from rotator_library.utils.paths import get_logs_dir, get_data_file
-
 LOG_DIR = get_logs_dir(_root_dir)
 
-# Configure a console handler with color (INFO and above only, no DEBUG)
+# Configure logging
+import colorlog
+
 console_handler = colorlog.StreamHandler(sys.stdout)
 console_handler.setLevel(logging.INFO)
 formatter = colorlog.ColoredFormatter(
@@ -277,14 +162,13 @@ formatter = colorlog.ColoredFormatter(
 )
 console_handler.setFormatter(formatter)
 
-# Configure a file handler for INFO-level logs and higher
+# File handlers
 info_file_handler = logging.FileHandler(LOG_DIR / "proxy.log", encoding="utf-8")
 info_file_handler.setLevel(logging.INFO)
 info_file_handler.setFormatter(
     logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 )
 
-# Configure a dedicated file handler for all DEBUG-level logs
 debug_file_handler = logging.FileHandler(LOG_DIR / "proxy_debug.log", encoding="utf-8")
 debug_file_handler.setLevel(logging.DEBUG)
 debug_file_handler.setFormatter(
@@ -292,33 +176,14 @@ debug_file_handler.setFormatter(
 )
 
 
-# Create a filter to ensure the debug handler ONLY gets DEBUG messages from the rotator_library
 class RotatorDebugFilter(logging.Filter):
     def filter(self, record):
-        return record.levelno == logging.DEBUG and record.name.startswith(
-            "rotator_library"
-        )
+        return record.levelno == logging.DEBUG and record.name.startswith("rotator_library")
 
 
 debug_file_handler.addFilter(RotatorDebugFilter())
 
-# Configure a console handler with color
-console_handler = colorlog.StreamHandler(sys.stdout)
-console_handler.setLevel(logging.INFO)
-formatter = colorlog.ColoredFormatter(
-    "%(log_color)s%(message)s",
-    log_colors={
-        "DEBUG": "cyan",
-        "INFO": "green",
-        "WARNING": "yellow",
-        "ERROR": "red",
-        "CRITICAL": "red,bg_white",
-    },
-)
-console_handler.setFormatter(formatter)
 
-
-# Add a filter to prevent any LiteLLM logs from cluttering the console
 class NoLiteLLMLogFilter(logging.Filter):
     def filter(self, record):
         return not record.name.startswith("LiteLLM")
@@ -326,1403 +191,80 @@ class NoLiteLLMLogFilter(logging.Filter):
 
 console_handler.addFilter(NoLiteLLMLogFilter())
 
-# Get the root logger and set it to DEBUG to capture all messages
+# Configure root logger
 root_logger = logging.getLogger()
 root_logger.setLevel(logging.DEBUG)
-
-# Add all handlers to the root logger
 root_logger.addHandler(info_file_handler)
 root_logger.addHandler(console_handler)
 root_logger.addHandler(debug_file_handler)
 
-# Silence other noisy loggers by setting their level higher than root
+# Silence noisy loggers
 logging.getLogger("uvicorn").setLevel(logging.WARNING)
 logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("LiteLLM").setLevel(logging.WARNING)
 
-# Isolate LiteLLM's logger to prevent it from reaching the console.
-# We will capture its logs via the logger_fn callback in the client instead.
+# Isolate LiteLLM's logger
 litellm_logger = logging.getLogger("LiteLLM")
 litellm_logger.handlers = []
 litellm_logger.propagate = False
 
-# Now that logging is configured, log the module load time to debug file only
-logging.debug(f"Modules loaded in {_elapsed:.2f}s")
-
-# Load environment variables from .env file
-load_dotenv(_root_dir / ".env")
-
-# --- Configuration ---
-USE_EMBEDDING_BATCHER = False
-ENABLE_REQUEST_LOGGING = args.enable_request_logging
-ENABLE_RAW_LOGGING = args.enable_raw_logging
-if ENABLE_REQUEST_LOGGING:
-    logging.info(
-        "Transaction logging is enabled (library-level with provider correlation)."
-    )
-if ENABLE_RAW_LOGGING:
-    logging.info("Raw I/O logging is enabled (proxy boundary, unmodified HTTP data).")
-PROXY_API_KEY = os.getenv("PROXY_API_KEY")
-# Note: PROXY_API_KEY validation moved to server startup to allow credential tool to run first
-
-# Discover API keys from environment variables
-api_keys = {}
-for key, value in os.environ.items():
-    if "_API_KEY" in key and key != "PROXY_API_KEY":
-        provider = key.split("_API_KEY")[0].lower()
-        if provider not in api_keys:
-            api_keys[provider] = []
-        api_keys[provider].append(value)
-
-# Load model ignore lists from environment variables
-ignore_models = {}
-for key, value in os.environ.items():
-    if key.startswith("IGNORE_MODELS_"):
-        provider = key.replace("IGNORE_MODELS_", "").lower()
-        models_to_ignore = [
-            model.strip() for model in value.split(",") if model.strip()
-        ]
-        ignore_models[provider] = models_to_ignore
-        logging.debug(
-            f"Loaded ignore list for provider '{provider}': {models_to_ignore}"
-        )
-
-# Load model whitelist from environment variables
-whitelist_models = {}
-for key, value in os.environ.items():
-    if key.startswith("WHITELIST_MODELS_"):
-        provider = key.replace("WHITELIST_MODELS_", "").lower()
-        models_to_whitelist = [
-            model.strip() for model in value.split(",") if model.strip()
-        ]
-        whitelist_models[provider] = models_to_whitelist
-        logging.debug(
-            f"Loaded whitelist for provider '{provider}': {models_to_whitelist}"
-        )
-
-# Load max concurrent requests per key from environment variables
-max_concurrent_requests_per_key = {}
-for key, value in os.environ.items():
-    if key.startswith("MAX_CONCURRENT_REQUESTS_PER_KEY_"):
-        provider = key.replace("MAX_CONCURRENT_REQUESTS_PER_KEY_", "").lower()
-        try:
-            max_concurrent = int(value)
-            if max_concurrent < 1:
-                logging.warning(
-                    f"Invalid max_concurrent value for provider '{provider}': {value}. Must be >= 1. Using default (1)."
-                )
-                max_concurrent = 1
-            max_concurrent_requests_per_key[provider] = max_concurrent
-            logging.debug(
-                f"Loaded max concurrent requests for provider '{provider}': {max_concurrent}"
-            )
-        except ValueError:
-            logging.warning(
-                f"Invalid max_concurrent value for provider '{provider}': {value}. Using default (1)."
-            )
-
-
-# --- Lifespan Management ---
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    """Manage the RotatingClient's lifecycle with the app's lifespan."""
-    # [MODIFIED] Perform skippable OAuth initialization at startup
-    skip_oauth_init = os.getenv("SKIP_OAUTH_INIT_CHECK", "false").lower() == "true"
-
-    # The CredentialManager now handles all discovery, including .env overrides.
-    # We pass all environment variables to it for this purpose.
-    cred_manager = CredentialManager(os.environ)
-    oauth_credentials = cred_manager.discover_and_prepare()
-
-    if not skip_oauth_init and oauth_credentials:
-        logging.info("Starting OAuth credential validation and deduplication...")
-        processed_emails = {}  # email -> {provider: path}
-        credentials_to_initialize = {}  # provider -> [paths]
-        final_oauth_credentials = {}
-
-        # --- Pass 1: Pre-initialization Scan & Deduplication ---
-        # logging.info("Pass 1: Scanning for existing metadata to find duplicates...")
-        for provider, paths in oauth_credentials.items():
-            if provider not in credentials_to_initialize:
-                credentials_to_initialize[provider] = []
-            for path in paths:
-                # Skip env-based credentials (virtual paths) - they don't have metadata files
-                if path.startswith("env://"):
-                    credentials_to_initialize[provider].append(path)
-                    continue
-
-                try:
-                    with open(path, "r") as f:
-                        data = json.load(f)
-                    metadata = data.get("_proxy_metadata", {})
-                    email = metadata.get("email")
-
-                    if email:
-                        if email not in processed_emails:
-                            processed_emails[email] = {}
-
-                        if provider in processed_emails[email]:
-                            original_path = processed_emails[email][provider]
-                            logging.warning(
-                                f"Duplicate for '{email}' on '{provider}' found in pre-scan: '{Path(path).name}'. Original: '{Path(original_path).name}'. Skipping."
-                            )
-                            continue
-                        else:
-                            processed_emails[email][provider] = path
-
-                    credentials_to_initialize[provider].append(path)
-
-                except (FileNotFoundError, json.JSONDecodeError) as e:
-                    logging.warning(
-                        f"Could not pre-read metadata from '{path}': {e}. Will process during initialization."
-                    )
-                    credentials_to_initialize[provider].append(path)
-
-        # --- Pass 2: Parallel Initialization of Filtered Credentials ---
-        # logging.info("Pass 2: Initializing unique credentials and performing final check...")
-        async def process_credential(provider: str, path: str, provider_instance):
-            """Process a single credential: initialize and fetch user info."""
-            try:
-                await provider_instance.initialize_token(path)
-
-                if not hasattr(provider_instance, "get_user_info"):
-                    return (provider, path, None, None)
-
-                user_info = await provider_instance.get_user_info(path)
-                email = user_info.get("email")
-                return (provider, path, email, None)
-
-            except Exception as e:
-                logging.error(
-                    f"Failed to process OAuth token for {provider} at '{path}': {e}"
-                )
-                return (provider, path, None, e)
-
-        # Collect all tasks for parallel execution
-        tasks = []
-        for provider, paths in credentials_to_initialize.items():
-            if not paths:
-                continue
-
-            provider_plugin_class = PROVIDER_PLUGINS.get(provider)
-            if not provider_plugin_class:
-                continue
-
-            provider_instance = provider_plugin_class()
-
-            for path in paths:
-                tasks.append(process_credential(provider, path, provider_instance))
-
-        # Execute all credential processing tasks in parallel
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-
-        # --- Pass 3: Sequential Deduplication and Final Assembly ---
-        for result in results:
-            # Handle exceptions from gather
-            if isinstance(result, Exception):
-                logging.error(f"Credential processing raised exception: {result}")
-                continue
-
-            provider, path, email, error = result
-
-            # Skip if there was an error
-            if error:
-                continue
-
-            # If provider doesn't support get_user_info, add directly
-            if email is None:
-                if provider not in final_oauth_credentials:
-                    final_oauth_credentials[provider] = []
-                final_oauth_credentials[provider].append(path)
-                continue
-
-            # Handle empty email
-            if not email:
-                logging.warning(
-                    f"Could not retrieve email for '{path}'. Treating as unique."
-                )
-                if provider not in final_oauth_credentials:
-                    final_oauth_credentials[provider] = []
-                final_oauth_credentials[provider].append(path)
-                continue
-
-            # Deduplication check
-            if email not in processed_emails:
-                processed_emails[email] = {}
-
-            if (
-                provider in processed_emails[email]
-                and processed_emails[email][provider] != path
-            ):
-                original_path = processed_emails[email][provider]
-                logging.warning(
-                    f"Duplicate for '{email}' on '{provider}' found post-init: '{Path(path).name}'. Original: '{Path(original_path).name}'. Skipping."
-                )
-                continue
-            else:
-                processed_emails[email][provider] = path
-                if provider not in final_oauth_credentials:
-                    final_oauth_credentials[provider] = []
-                final_oauth_credentials[provider].append(path)
-
-                # Update metadata (skip for env-based credentials - they don't have files)
-                if not path.startswith("env://"):
-                    try:
-                        with open(path, "r+") as f:
-                            data = json.load(f)
-                            metadata = data.get("_proxy_metadata", {})
-                            metadata["email"] = email
-                            metadata["last_check_timestamp"] = time.time()
-                            data["_proxy_metadata"] = metadata
-                            f.seek(0)
-                            json.dump(data, f, indent=2)
-                            f.truncate()
-                    except Exception as e:
-                        logging.error(f"Failed to update metadata for '{path}': {e}")
-
-        logging.info("OAuth credential processing complete.")
-        oauth_credentials = final_oauth_credentials
-
-    # [NEW] Load provider-specific params
-    litellm_provider_params = {
-        "gemini_cli": {"project_id": os.getenv("GEMINI_CLI_PROJECT_ID")}
-    }
-
-    # Load global timeout from environment (default 30 seconds)
-    global_timeout = int(os.getenv("GLOBAL_TIMEOUT", "30"))
-
-    # The client now uses the root logger configuration
-    client = RotatingClient(
-        api_keys=api_keys,
-        oauth_credentials=oauth_credentials,  # Pass OAuth config
-        configure_logging=True,
-        global_timeout=global_timeout,
-        litellm_provider_params=litellm_provider_params,
-        ignore_models=ignore_models,
-        whitelist_models=whitelist_models,
-        enable_request_logging=ENABLE_REQUEST_LOGGING,
-        max_concurrent_requests_per_key=max_concurrent_requests_per_key,
-    )
-
-    await client.initialize_usage_managers()
-
-    # Log loaded credentials summary (compact, always visible for deployment verification)
-    # _api_summary = ', '.join([f"{p}:{len(c)}" for p, c in api_keys.items()]) if api_keys else "none"
-    # _oauth_summary = ', '.join([f"{p}:{len(c)}" for p, c in oauth_credentials.items()]) if oauth_credentials else "none"
-    # _total_summary = ', '.join([f"{p}:{len(c)}" for p, c in client.all_credentials.items()])
-    # print(f"🔑 Credentials loaded: {_total_summary} (API: {_api_summary} | OAuth: {_oauth_summary})")
-    client.background_refresher.start()  # Start the background task
-    app.state.rotating_client = client
-
-    # Warn if no provider credentials are configured
-    if not client.all_credentials:
-        logging.warning("=" * 70)
-        logging.warning("⚠️  NO PROVIDER CREDENTIALS CONFIGURED")
-        logging.warning("The proxy is running but cannot serve any LLM requests.")
-        logging.warning(
-            "Launch the credential tool to add API keys or OAuth credentials."
-        )
-        logging.warning("  • Executable: Run with --add-credential flag")
-        logging.warning("  • Source: python src/proxy_app/main.py --add-credential")
-        logging.warning("=" * 70)
-
-    os.environ["LITELLM_LOG"] = "ERROR"
-    litellm.set_verbose = False
-    litellm.drop_params = True
-    if USE_EMBEDDING_BATCHER:
-        batcher = EmbeddingBatcher(client=client)
-        app.state.embedding_batcher = batcher
-        logging.info("RotatingClient and EmbeddingBatcher initialized.")
-    else:
-        app.state.embedding_batcher = None
-        logging.info("RotatingClient initialized (EmbeddingBatcher disabled).")
-
-    # Start model info service in background (fetches pricing/capabilities data)
-    # This runs asynchronously and doesn't block proxy startup
-    model_info_service = await init_model_info_service()
-    app.state.model_info_service = model_info_service
-    logging.info("Model info service started (fetching pricing data in background).")
-
-    yield
-
-    await client.background_refresher.stop()  # Stop the background task on shutdown
-    if app.state.embedding_batcher:
-        await app.state.embedding_batcher.stop()
-    await client.close()
-
-    # Stop model info service
-    if hasattr(app.state, "model_info_service") and app.state.model_info_service:
-        await app.state.model_info_service.stop()
-
-    if app.state.embedding_batcher:
-        logging.info("RotatingClient and EmbeddingBatcher closed.")
-    else:
-        logging.info("RotatingClient closed.")
-
-
-# --- FastAPI App Setup ---
-app = FastAPI(lifespan=lifespan)
-
-# Add CORS middleware to allow all origins, methods, and headers
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],  # Allows all origins
-    allow_credentials=True,
-    allow_methods=["*"],  # Allows all methods
-    allow_headers=["*"],  # Allows all headers
-)
-api_key_header = APIKeyHeader(name="Authorization", auto_error=False)
-
-
-def get_rotating_client(request: Request) -> RotatingClient:
-    """Dependency to get the rotating client instance from the app state."""
-    return request.app.state.rotating_client
-
-
-def get_embedding_batcher(request: Request) -> EmbeddingBatcher:
-    """Dependency to get the embedding batcher instance from the app state."""
-    return request.app.state.embedding_batcher
-
-
-async def verify_api_key(auth: str = Depends(api_key_header)):
-    """Dependency to verify the proxy API key."""
-    # If PROXY_API_KEY is not set or empty, skip verification (open access)
-    if not PROXY_API_KEY:
-        return auth
-    if not auth or auth != f"Bearer {PROXY_API_KEY}":
-        raise HTTPException(status_code=401, detail="Invalid or missing API Key")
-    return auth
-
-
-# --- Anthropic API Key Header ---
-anthropic_api_key_header = APIKeyHeader(name="x-api-key", auto_error=False)
-
-
-async def verify_anthropic_api_key(
-    x_api_key: str = Depends(anthropic_api_key_header),
-    auth: str = Depends(api_key_header),
-):
-    """
-    Dependency to verify API key for Anthropic endpoints.
-    Accepts either x-api-key header (Anthropic style) or Authorization Bearer (OpenAI style).
-    """
-    # Check x-api-key first (Anthropic style)
-    if x_api_key and x_api_key == PROXY_API_KEY:
-        return x_api_key
-    # Fall back to Bearer token (OpenAI style)
-    if auth and auth == f"Bearer {PROXY_API_KEY}":
-        return auth
-    raise HTTPException(status_code=401, detail="Invalid or missing API Key")
-
-
-async def streaming_response_wrapper(
-    request: Request,
-    request_data: dict,
-    response_stream: AsyncGenerator[str, None],
-    logger: Optional[RawIOLogger] = None,
-) -> AsyncGenerator[str, None]:
-    """
-    Wraps a streaming response to log the full response after completion
-    and ensures any errors during the stream are sent to the client.
-    """
-    response_chunks = []
-    full_response = {}
-
-    try:
-        async for chunk_str in response_stream:
-            if await request.is_disconnected():
-                logging.warning("Client disconnected, stopping stream.")
-                break
-            yield chunk_str
-            if chunk_str.strip() and chunk_str.startswith("data:"):
-                content = chunk_str[len("data:") :].strip()
-                if content != "[DONE]":
-                    try:
-                        chunk_data = json.loads(content)
-                        response_chunks.append(chunk_data)
-                        if logger:
-                            logger.log_stream_chunk(chunk_data)
-                    except json.JSONDecodeError:
-                        pass
-    except Exception as e:
-        logging.error(f"An error occurred during the response stream: {e}")
-        # Yield a final error message to the client to ensure they are not left hanging.
-        error_payload = {
-            "error": {
-                "message": f"An unexpected error occurred during the stream: {str(e)}",
-                "type": "proxy_internal_error",
-                "code": 500,
-            }
-        }
-        yield f"data: {json.dumps(error_payload)}\n\n"
-        yield "data: [DONE]\n\n"
-        # Also log this as a failed request
-        if logger:
-            logger.log_final_response(
-                status_code=500, headers=None, body={"error": str(e)}
-            )
-        return  # Stop further processing
-    finally:
-        if response_chunks:
-            # --- Aggregation Logic ---
-            final_message = {"role": "assistant"}
-            aggregated_tool_calls = {}
-            usage_data = None
-            finish_reason = None
-
-            for chunk in response_chunks:
-                if "choices" in chunk and chunk["choices"]:
-                    choice = chunk["choices"][0]
-                    delta = choice.get("delta", {})
-
-                    # Dynamically aggregate all fields from the delta
-                    for key, value in delta.items():
-                        if value is None:
-                            continue
-
-                        if key == "content":
-                            if "content" not in final_message:
-                                final_message["content"] = ""
-                            if value:
-                                final_message["content"] += value
-
-                        elif key == "tool_calls":
-                            for tc_chunk in value:
-                                index = tc_chunk["index"]
-                                if index not in aggregated_tool_calls:
-                                    aggregated_tool_calls[index] = {
-                                        "type": "function",
-                                        "function": {"name": "", "arguments": ""},
-                                    }
-                                # Ensure 'function' key exists for this index before accessing its sub-keys
-                                if "function" not in aggregated_tool_calls[index]:
-                                    aggregated_tool_calls[index]["function"] = {
-                                        "name": "",
-                                        "arguments": "",
-                                    }
-                                if tc_chunk.get("id"):
-                                    aggregated_tool_calls[index]["id"] = tc_chunk["id"]
-                                if "function" in tc_chunk:
-                                    if "name" in tc_chunk["function"]:
-                                        if tc_chunk["function"]["name"] is not None:
-                                            aggregated_tool_calls[index]["function"][
-                                                "name"
-                                            ] += tc_chunk["function"]["name"]
-                                    if "arguments" in tc_chunk["function"]:
-                                        if (
-                                            tc_chunk["function"]["arguments"]
-                                            is not None
-                                        ):
-                                            aggregated_tool_calls[index]["function"][
-                                                "arguments"
-                                            ] += tc_chunk["function"]["arguments"]
-
-                        elif key == "function_call":
-                            if "function_call" not in final_message:
-                                final_message["function_call"] = {
-                                    "name": "",
-                                    "arguments": "",
-                                }
-                            if "name" in value:
-                                if value["name"] is not None:
-                                    final_message["function_call"]["name"] += value[
-                                        "name"
-                                    ]
-                            if "arguments" in value:
-                                if value["arguments"] is not None:
-                                    final_message["function_call"]["arguments"] += (
-                                        value["arguments"]
-                                    )
-
-                        else:  # Generic key handling for other data like 'reasoning'
-                            # FIX: Role should always replace, never concatenate
-                            if key == "role":
-                                final_message[key] = value
-                            elif key not in final_message:
-                                final_message[key] = value
-                            elif isinstance(final_message.get(key), str):
-                                final_message[key] += value
-                            else:
-                                final_message[key] = value
-
-                    if "finish_reason" in choice and choice["finish_reason"]:
-                        finish_reason = choice["finish_reason"]
-
-                if "usage" in chunk and chunk["usage"]:
-                    usage_data = chunk["usage"]
-
-            # --- Final Response Construction ---
-            if aggregated_tool_calls:
-                final_message["tool_calls"] = list(aggregated_tool_calls.values())
-                # CRITICAL FIX: Override finish_reason when tool_calls exist
-                # This ensures OpenCode and other agentic systems continue the conversation loop
-                finish_reason = "tool_calls"
-
-            # Ensure standard fields are present for consistent logging
-            for field in ["content", "tool_calls", "function_call"]:
-                if field not in final_message:
-                    final_message[field] = None
-
-            first_chunk = response_chunks[0]
-            final_choice = {
-                "index": 0,
-                "message": final_message,
-                "finish_reason": finish_reason,
-            }
-
-            full_response = {
-                "id": first_chunk.get("id"),
-                "object": "chat.completion",
-                "created": first_chunk.get("created"),
-                "model": first_chunk.get("model"),
-                "choices": [final_choice],
-                "usage": usage_data,
-            }
-
-        if logger:
-            logger.log_final_response(
-                status_code=200,
-                headers=None,  # Headers are not available at this stage
-                body=full_response,
-            )
-
-
-@app.post("/v1/chat/completions")
-async def chat_completions(
-    request: Request,
-    client: RotatingClient = Depends(get_rotating_client),
-    _=Depends(verify_api_key),
-):
-    """
-    OpenAI-compatible endpoint powered by the RotatingClient.
-    Handles both streaming and non-streaming responses and logs them.
-    """
-    # Raw I/O logger captures unmodified HTTP data at proxy boundary (disabled by default)
-    raw_logger = RawIOLogger() if ENABLE_RAW_LOGGING else None
-    try:
-        # Read and parse the request body only once at the beginning.
-        try:
-            request_data = await request.json()
-        except json.JSONDecodeError:
-            raise HTTPException(status_code=400, detail="Invalid JSON in request body.")
-
-        # Global temperature=0 override (controlled by .env variable, default: OFF)
-        # Low temperature makes models deterministic and prone to following training data
-        # instead of actual schemas, which can cause tool hallucination
-        # Modes: "remove" = delete temperature key, "set" = change to 1.0, "false" = disabled
-        override_temp_zero = os.getenv("OVERRIDE_TEMPERATURE_ZERO", "false").lower()
-
-        if (
-            override_temp_zero in ("remove", "set", "true", "1", "yes")
-            and "temperature" in request_data
-            and request_data["temperature"] == 0
-        ):
-            if override_temp_zero == "remove":
-                # Remove temperature key entirely
-                del request_data["temperature"]
-                logging.debug(
-                    "OVERRIDE_TEMPERATURE_ZERO=remove: Removed temperature=0 from request"
-                )
-            else:
-                # Set to 1.0 (for "set", "true", "1", "yes")
-                request_data["temperature"] = 1.0
-                logging.debug(
-                    "OVERRIDE_TEMPERATURE_ZERO=set: Converting temperature=0 to temperature=1.0"
-                )
-
-        # If raw logging is enabled, capture the unmodified request data.
-        if raw_logger:
-            raw_logger.log_request(headers=request.headers, body=request_data)
-
-        # Extract and log specific reasoning parameters for monitoring.
-        model = request_data.get("model")
-        generation_cfg = (
-            request_data.get("generationConfig", {})
-            or request_data.get("generation_config", {})
-            or {}
-        )
-        reasoning_effort = request_data.get("reasoning_effort") or generation_cfg.get(
-            "reasoning_effort"
-        )
-
-        logging.getLogger("rotator_library").debug(
-            f"Handling reasoning parameters: model={model}, reasoning_effort={reasoning_effort}"
-        )
-
-        # Log basic request info to console (this is a separate, simpler logger).
-        log_request_to_console(
-            url=str(request.url),
-            headers=dict(request.headers),
-            client_info=(request.client.host, request.client.port),
-            request_data=request_data,
-        )
-        is_streaming = request_data.get("stream", False)
-
-        if is_streaming:
-            response_generator = await client.acompletion(
-                request=request, **request_data
-            )
-            return StreamingResponse(
-                streaming_response_wrapper(
-                    request, request_data, response_generator, raw_logger
-                ),
-                media_type="text/event-stream",
-            )
-        else:
-            response = await client.acompletion(request=request, **request_data)
-            if raw_logger:
-                # Assuming response has status_code and headers attributes
-                # This might need adjustment based on the actual response object
-                response_headers = (
-                    response.headers if hasattr(response, "headers") else None
-                )
-                status_code = (
-                    response.status_code if hasattr(response, "status_code") else 200
-                )
-                raw_logger.log_final_response(
-                    status_code=status_code,
-                    headers=response_headers,
-                    body=response.model_dump(),
-                )
-            return response
-
-    except (
-        litellm.InvalidRequestError,
-        ValueError,
-        litellm.ContextWindowExceededError,
-    ) as e:
-        raise HTTPException(status_code=400, detail=f"Invalid Request: {str(e)}")
-    except litellm.AuthenticationError as e:
-        raise HTTPException(status_code=401, detail=f"Authentication Error: {str(e)}")
-    except litellm.RateLimitError as e:
-        raise HTTPException(status_code=429, detail=f"Rate Limit Exceeded: {str(e)}")
-    except (litellm.ServiceUnavailableError, litellm.APIConnectionError) as e:
-        raise HTTPException(status_code=503, detail=f"Service Unavailable: {str(e)}")
-    except litellm.Timeout as e:
-        raise HTTPException(status_code=504, detail=f"Gateway Timeout: {str(e)}")
-    except (litellm.InternalServerError, litellm.OpenAIError) as e:
-        raise HTTPException(status_code=502, detail=f"Bad Gateway: {str(e)}")
-    except Exception as e:
-        logging.error(f"Request failed after all retries: {e}")
-        # Optionally log the failed request
-        if ENABLE_REQUEST_LOGGING:
-            try:
-                request_data = await request.json()
-            except json.JSONDecodeError:
-                request_data = {"error": "Could not parse request body"}
-            if raw_logger:
-                raw_logger.log_final_response(
-                    status_code=500, headers=None, body={"error": str(e)}
-                )
-        raise HTTPException(status_code=500, detail=str(e))
-
-
-# --- Anthropic Messages API Endpoint ---
-@app.post("/v1/messages")
-async def anthropic_messages(
-    request: Request,
-    body: AnthropicMessagesRequest,
-    client: RotatingClient = Depends(get_rotating_client),
-    _=Depends(verify_anthropic_api_key),
-):
-    """
-    Anthropic-compatible Messages API endpoint.
-
-    Accepts requests in Anthropic's format and returns responses in Anthropic's format.
-    Internally translates to OpenAI format for processing via LiteLLM.
-
-    This endpoint is compatible with Claude Code and other Anthropic API clients.
-    """
-    # Initialize raw I/O logger if enabled (for debugging proxy boundary)
-    logger = RawIOLogger() if ENABLE_RAW_LOGGING else None
-
-    # Log raw Anthropic request if raw logging is enabled
-    if logger:
-        logger.log_request(
-            headers=dict(request.headers),
-            body=body.model_dump(exclude_none=True),
-        )
-
-    try:
-        # Log the request to console
-        log_request_to_console(
-            url=str(request.url),
-            headers=dict(request.headers),
-            client_info=(
-                request.client.host if request.client else "unknown",
-                request.client.port if request.client else 0,
-            ),
-            request_data=body.model_dump(exclude_none=True),
-        )
-
-        # Use the library method to handle the request
-        result = await client.anthropic_messages(body, raw_request=request)
-
-        if body.stream:
-            # Streaming response
-            return StreamingResponse(
-                result,
-                media_type="text/event-stream",
-                headers={
-                    "Cache-Control": "no-cache",
-                    "Connection": "keep-alive",
-                    "X-Accel-Buffering": "no",
-                },
-            )
-        else:
-            # Non-streaming response
-            if logger:
-                logger.log_final_response(
-                    status_code=200,
-                    headers=None,
-                    body=result,
-                )
-            return JSONResponse(content=result)
-
-    except (
-        litellm.InvalidRequestError,
-        ValueError,
-        litellm.ContextWindowExceededError,
-    ) as e:
-        error_response = {
-            "type": "error",
-            "error": {"type": "invalid_request_error", "message": str(e)},
-        }
-        raise HTTPException(status_code=400, detail=error_response)
-    except litellm.AuthenticationError as e:
-        error_response = {
-            "type": "error",
-            "error": {"type": "authentication_error", "message": str(e)},
-        }
-        raise HTTPException(status_code=401, detail=error_response)
-    except litellm.RateLimitError as e:
-        error_response = {
-            "type": "error",
-            "error": {"type": "rate_limit_error", "message": str(e)},
-        }
-        raise HTTPException(status_code=429, detail=error_response)
-    except (litellm.ServiceUnavailableError, litellm.APIConnectionError) as e:
-        error_response = {
-            "type": "error",
-            "error": {"type": "api_error", "message": str(e)},
-        }
-        raise HTTPException(status_code=503, detail=error_response)
-    except litellm.Timeout as e:
-        error_response = {
-            "type": "error",
-            "error": {"type": "api_error", "message": f"Request timed out: {str(e)}"},
-        }
-        raise HTTPException(status_code=504, detail=error_response)
-    except Exception as e:
-        logging.error(f"Anthropic messages endpoint error: {e}")
-        if logger:
-            logger.log_final_response(
-                status_code=500,
-                headers=None,
-                body={"error": str(e)},
-            )
-        error_response = {
-            "type": "error",
-            "error": {"type": "api_error", "message": str(e)},
-        }
-        raise HTTPException(status_code=500, detail=error_response)
-
-
-# --- Anthropic Count Tokens Endpoint ---
-@app.post("/v1/messages/count_tokens")
-async def anthropic_count_tokens(
-    request: Request,
-    body: AnthropicCountTokensRequest,
-    client: RotatingClient = Depends(get_rotating_client),
-    _=Depends(verify_anthropic_api_key),
-):
-    """
-    Anthropic-compatible count_tokens endpoint.
-
-    Counts the number of tokens that would be used by a Messages API request.
-    This is useful for estimating costs and managing context windows.
-
-    Accepts requests in Anthropic's format and returns token count in Anthropic's format.
-    """
-    try:
-        # Use the library method to handle the request
-        result = await client.anthropic_count_tokens(body)
-        return JSONResponse(content=result)
-
-    except (
-        litellm.InvalidRequestError,
-        ValueError,
-        litellm.ContextWindowExceededError,
-    ) as e:
-        error_response = {
-            "type": "error",
-            "error": {"type": "invalid_request_error", "message": str(e)},
-        }
-        raise HTTPException(status_code=400, detail=error_response)
-    except litellm.AuthenticationError as e:
-        error_response = {
-            "type": "error",
-            "error": {"type": "authentication_error", "message": str(e)},
-        }
-        raise HTTPException(status_code=401, detail=error_response)
-    except Exception as e:
-        logging.error(f"Anthropic count_tokens endpoint error: {e}")
-        error_response = {
-            "type": "error",
-            "error": {"type": "api_error", "message": str(e)},
-        }
-        raise HTTPException(status_code=500, detail=error_response)
-
-
-@app.post("/v1/embeddings")
-async def embeddings(
-    request: Request,
-    body: EmbeddingRequest,
-    client: RotatingClient = Depends(get_rotating_client),
-    batcher: Optional[EmbeddingBatcher] = Depends(get_embedding_batcher),
-    _=Depends(verify_api_key),
-):
-    """
-    OpenAI-compatible endpoint for creating embeddings.
-    Supports two modes based on the USE_EMBEDDING_BATCHER flag:
-    - True: Uses a server-side batcher for high throughput.
-    - False: Passes requests directly to the provider.
-    """
-    try:
-        request_data = body.model_dump(exclude_none=True)
-        log_request_to_console(
-            url=str(request.url),
-            headers=dict(request.headers),
-            client_info=(request.client.host, request.client.port),
-            request_data=request_data,
-        )
-        if USE_EMBEDDING_BATCHER and batcher:
-            # --- Server-Side Batching Logic ---
-            request_data = body.model_dump(exclude_none=True)
-            inputs = request_data.get("input", [])
-            if isinstance(inputs, str):
-                inputs = [inputs]
-
-            tasks = []
-            for single_input in inputs:
-                individual_request = request_data.copy()
-                individual_request["input"] = single_input
-                tasks.append(batcher.add_request(individual_request))
-
-            results = await asyncio.gather(*tasks)
-
-            all_data = []
-            total_prompt_tokens = 0
-            total_tokens = 0
-            for i, result in enumerate(results):
-                result["data"][0]["index"] = i
-                all_data.extend(result["data"])
-                total_prompt_tokens += result["usage"]["prompt_tokens"]
-                total_tokens += result["usage"]["total_tokens"]
-
-            final_response_data = {
-                "object": "list",
-                "model": results[0]["model"],
-                "data": all_data,
-                "usage": {
-                    "prompt_tokens": total_prompt_tokens,
-                    "total_tokens": total_tokens,
-                },
-            }
-            response = litellm.EmbeddingResponse(**final_response_data)
-
-        else:
-            # --- Direct Pass-Through Logic ---
-            request_data = body.model_dump(exclude_none=True)
-            if isinstance(request_data.get("input"), str):
-                request_data["input"] = [request_data["input"]]
-
-            response = await client.aembedding(request=request, **request_data)
-
-        return response
-
-    except HTTPException as e:
-        # Re-raise HTTPException to ensure it's not caught by the generic Exception handler
-        raise e
-    except (
-        litellm.InvalidRequestError,
-        ValueError,
-        litellm.ContextWindowExceededError,
-    ) as e:
-        raise HTTPException(status_code=400, detail=f"Invalid Request: {str(e)}")
-    except litellm.AuthenticationError as e:
-        raise HTTPException(status_code=401, detail=f"Authentication Error: {str(e)}")
-    except litellm.RateLimitError as e:
-        raise HTTPException(status_code=429, detail=f"Rate Limit Exceeded: {str(e)}")
-    except (litellm.ServiceUnavailableError, litellm.APIConnectionError) as e:
-        raise HTTPException(status_code=503, detail=f"Service Unavailable: {str(e)}")
-    except litellm.Timeout as e:
-        raise HTTPException(status_code=504, detail=f"Gateway Timeout: {str(e)}")
-    except (litellm.InternalServerError, litellm.OpenAIError) as e:
-        raise HTTPException(status_code=502, detail=f"Bad Gateway: {str(e)}")
-    except Exception as e:
-        logging.error(f"Embedding request failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
-
-
-@app.get("/")
-def read_root():
-    return {"Status": "API Key Proxy is running"}
-
-
-@app.get("/v1/models")
-async def list_models(
-    request: Request,
-    client: RotatingClient = Depends(get_rotating_client),
-    _=Depends(verify_api_key),
-    enriched: bool = True,
-):
-    """
-    Returns a list of available models in the OpenAI-compatible format.
-
-    Query Parameters:
-        enriched: If True (default), returns detailed model info with pricing and capabilities.
-                  If False, returns minimal OpenAI-compatible response.
-    """
-    model_ids = await client.get_all_available_models(grouped=False)
-
-    if enriched and hasattr(request.app.state, "model_info_service"):
-        model_info_service = request.app.state.model_info_service
-        if model_info_service.is_ready:
-            # Return enriched model data
-            enriched_data = model_info_service.enrich_model_list(model_ids)
-            return {"object": "list", "data": enriched_data}
-
-    # Fallback to basic model cards
-    model_cards = [
-        {
-            "id": model_id,
-            "object": "model",
-            "created": int(time.time()),
-            "owned_by": "Mirro-Proxy",
-        }
-        for model_id in model_ids
-    ]
-    return {"object": "list", "data": model_cards}
-
-
-@app.get("/v1/models/{model_id:path}")
-async def get_model(
-    model_id: str,
-    request: Request,
-    _=Depends(verify_api_key),
-):
-    """
-    Returns detailed information about a specific model.
-
-    Path Parameters:
-        model_id: The model ID (e.g., "anthropic/claude-3-opus", "openrouter/openai/gpt-4")
-    """
-    if hasattr(request.app.state, "model_info_service"):
-        model_info_service = request.app.state.model_info_service
-        if model_info_service.is_ready:
-            info = model_info_service.get_model_info(model_id)
-            if info:
-                return info.to_dict()
-
-    # Return basic info if service not ready or model not found
-    return {
-        "id": model_id,
-        "object": "model",
-        "created": int(time.time()),
-        "owned_by": model_id.split("/")[0] if "/" in model_id else "unknown",
-    }
-
-
-@app.get("/v1/model-info/stats")
-async def model_info_stats(
-    request: Request,
-    _=Depends(verify_api_key),
-):
-    """
-    Returns statistics about the model info service (for monitoring/debugging).
-    """
-    if hasattr(request.app.state, "model_info_service"):
-        return request.app.state.model_info_service.get_stats()
-    return {"error": "Model info service not initialized"}
-
-
-@app.get("/v1/providers")
-async def list_providers(_=Depends(verify_api_key)):
-    """
-    Returns a list of all available providers.
-    """
-    return list(PROVIDER_PLUGINS.keys())
-
-
-@app.get("/v1/quota-stats")
-async def get_quota_stats(
-    request: Request,
-    client: RotatingClient = Depends(get_rotating_client),
-    _=Depends(verify_api_key),
-    provider: str = None,
-):
-    """
-    Returns quota and usage statistics for all credentials.
-
-    This returns cached data from the proxy without making external API calls.
-    Use POST to reload from disk or force refresh from external APIs.
-
-    Query Parameters:
-        provider: Optional filter to return stats for a specific provider only
-
-    Returns:
-        {
-            "providers": {
-                "provider_name": {
-                    "credential_count": int,
-                    "active_count": int,
-                    "on_cooldown_count": int,
-                    "exhausted_count": int,
-                    "total_requests": int,
-                    "tokens": {...},
-                    "approx_cost": float | null,
-                    "quota_groups": {...},  // For Antigravity
-                    "credentials": [...]
-                }
-            },
-            "summary": {...},
-            "data_source": "cache",
-            "timestamp": float
-        }
-    """
-    try:
-        stats = await client.get_quota_stats(provider_filter=provider)
-        return stats
-    except Exception as e:
-        logging.error(f"Failed to get quota stats: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
-
-
-@app.post("/v1/quota-stats")
-async def refresh_quota_stats(
-    request: Request,
-    client: RotatingClient = Depends(get_rotating_client),
-    _=Depends(verify_api_key),
-):
-    """
-    Refresh quota and usage statistics.
-
-    Request body:
-        {
-            "action": "reload" | "force_refresh",
-            "scope": "all" | "provider" | "credential",
-            "provider": "antigravity",  // required if scope != "all"
-            "credential": "antigravity_oauth_1.json"  // required if scope == "credential"
-        }
-
-    Actions:
-        - reload: Re-read data from disk (no external API calls)
-        - force_refresh: For Antigravity, fetch live quota from API.
-                        For other providers, same as reload.
-
-    Returns:
-        Same as GET, plus a "refresh_result" field with operation details.
-    """
-    try:
-        data = await request.json()
-        action = data.get("action", "reload")
-        scope = data.get("scope", "all")
-        provider = data.get("provider")
-        credential = data.get("credential")
-
-        # Validate parameters
-        if action not in ("reload", "force_refresh"):
-            raise HTTPException(
-                status_code=400,
-                detail="action must be 'reload' or 'force_refresh'",
-            )
-
-        if scope not in ("all", "provider", "credential"):
-            raise HTTPException(
-                status_code=400,
-                detail="scope must be 'all', 'provider', or 'credential'",
-            )
-
-        if scope in ("provider", "credential") and not provider:
-            raise HTTPException(
-                status_code=400,
-                detail="'provider' is required when scope is 'provider' or 'credential'",
-            )
-
-        if scope == "credential" and not credential:
-            raise HTTPException(
-                status_code=400,
-                detail="'credential' is required when scope is 'credential'",
-            )
-
-        refresh_result = {
-            "action": action,
-            "scope": scope,
-            "provider": provider,
-            "credential": credential,
-        }
-
-        if action == "reload":
-            # Just reload from disk
-            start_time = time.time()
-            await client.reload_usage_from_disk()
-            refresh_result["duration_ms"] = int((time.time() - start_time) * 1000)
-            refresh_result["success"] = True
-            refresh_result["message"] = "Reloaded usage data from disk"
-
-        elif action == "force_refresh":
-            # Force refresh from external API (for supported providers like Antigravity)
-            result = await client.force_refresh_quota(
-                provider=provider if scope in ("provider", "credential") else None,
-                credential=credential if scope == "credential" else None,
-            )
-            refresh_result.update(result)
-            refresh_result["success"] = result["failed_count"] == 0
-
-        # Get updated stats
-        stats = await client.get_quota_stats(provider_filter=provider)
-        stats["refresh_result"] = refresh_result
-        stats["data_source"] = "refreshed"
-
-        return stats
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logging.error(f"Failed to refresh quota stats: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
-
-
-@app.post("/v1/token-count")
-async def token_count(
-    request: Request,
-    client: RotatingClient = Depends(get_rotating_client),
-    _=Depends(verify_api_key),
-):
-    """
-    Calculates the token count for a given list of messages and a model.
-    """
-    try:
-        data = await request.json()
-        model = data.get("model")
-        messages = data.get("messages")
-
-        if not model or not messages:
-            raise HTTPException(
-                status_code=400, detail="'model' and 'messages' are required."
-            )
-
-        count = client.token_count(**data)
-        return {"token_count": count}
-
-    except Exception as e:
-        logging.error(f"Token count failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
-
-
-@app.post("/v1/cost-estimate")
-async def cost_estimate(request: Request, _=Depends(verify_api_key)):
-    """
-    Estimates the cost for a request based on token counts and model pricing.
-
-    Request body:
-        {
-            "model": "anthropic/claude-3-opus",
-            "prompt_tokens": 1000,
-            "completion_tokens": 500,
-            "cache_read_tokens": 0,       # optional
-            "cache_creation_tokens": 0    # optional
-        }
-
-    Returns:
-        {
-            "model": "anthropic/claude-3-opus",
-            "cost": 0.0375,
-            "currency": "USD",
-            "pricing": {
-                "input_cost_per_token": 0.000015,
-                "output_cost_per_token": 0.000075
-            },
-            "source": "model_info_service"  # or "litellm_fallback"
-        }
-    """
-    try:
-        data = await request.json()
-        model = data.get("model")
-        prompt_tokens = data.get("prompt_tokens", 0)
-        completion_tokens = data.get("completion_tokens", 0)
-        cache_read_tokens = data.get("cache_read_tokens", 0)
-        cache_creation_tokens = data.get("cache_creation_tokens", 0)
-
-        if not model:
-            raise HTTPException(status_code=400, detail="'model' is required.")
-
-        result = {
-            "model": model,
-            "cost": None,
-            "currency": "USD",
-            "pricing": {},
-            "source": None,
-        }
-
-        # Try model info service first
-        if hasattr(request.app.state, "model_info_service"):
-            model_info_service = request.app.state.model_info_service
-            if model_info_service.is_ready:
-                cost = model_info_service.calculate_cost(
-                    model,
-                    prompt_tokens,
-                    completion_tokens,
-                    cache_read_tokens,
-                    cache_creation_tokens,
-                )
-                if cost is not None:
-                    cost_info = model_info_service.get_cost_info(model)
-                    result["cost"] = cost
-                    result["pricing"] = cost_info or {}
-                    result["source"] = "model_info_service"
-                    return result
-
-        # Fallback to litellm
-        try:
-            import litellm
-
-            # Create a mock response for cost calculation
-            model_info = litellm.get_model_info(model)
-            input_cost = model_info.get("input_cost_per_token", 0)
-            output_cost = model_info.get("output_cost_per_token", 0)
-
-            if input_cost or output_cost:
-                cost = (prompt_tokens * input_cost) + (completion_tokens * output_cost)
-                result["cost"] = cost
-                result["pricing"] = {
-                    "input_cost_per_token": input_cost,
-                    "output_cost_per_token": output_cost,
-                }
-                result["source"] = "litellm_fallback"
-                return result
-        except Exception:
-            pass
-
-        result["source"] = "unknown"
-        result["error"] = "Pricing data not available for this model"
-        return result
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logging.error(f"Cost estimate failed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
-
+# Set environment flags from args
+if args.enable_request_logging:
+    os.environ["ENABLE_REQUEST_LOGGING"] = "true"
+    logging.info("Transaction logging is enabled.")
+
+if args.enable_raw_logging:
+    os.environ["ENABLE_RAW_LOGGING"] = "true"
+    logging.info("Raw I/O logging is enabled.")
+
+# Create the FastAPI application
+app = create_app(data_dir=_root_dir)
 
 if __name__ == "__main__":
-    # Define ENV_FILE for onboarding checks using centralized path
+    import uvicorn
+
+    # Check for onboarding
     ENV_FILE = get_data_file(".env")
 
-    # Check if launcher TUI should be shown (no arguments provided)
-    if len(sys.argv) == 1:
-        # No arguments - show launcher TUI (lazy import)
-        from proxy_app.launcher_tui import run_launcher_tui
-
-        run_launcher_tui()
-        # Launcher modifies sys.argv and returns, or exits if user chose Exit
-        # If we get here, user chose "Run Proxy" and sys.argv is modified
-        # Re-parse arguments with modified sys.argv
-        args = parser.parse_args()
-
     def needs_onboarding() -> bool:
-        """
-        Check if the proxy needs onboarding (first-time setup).
-        Returns True if onboarding is needed, False otherwise.
-        """
-        # Only check if .env file exists
-        # PROXY_API_KEY is optional (will show warning if not set)
-        if not ENV_FILE.is_file():
-            return True
-
-        return False
+        """Check if the proxy needs onboarding."""
+        return not ENV_FILE.is_file()
 
     def show_onboarding_message():
-        """Display clear explanatory message for why onboarding is needed."""
-        os.system(
-            "cls" if os.name == "nt" else "clear"
-        )  # Clear terminal for clean presentation
-        console.print(
+        """Display onboarding message."""
+        from rich.panel import Panel
+
+        _console.print(
             Panel.fit(
                 "[bold cyan]🚀 LLM API Key Proxy - First Time Setup[/bold cyan]",
                 border_style="cyan",
             )
         )
-        console.print("[bold yellow]:warning:  Configuration Required[/bold yellow]\n")
-
-        console.print("The proxy needs initial configuration:")
-        console.print("  [red]:x: No .env file found[/red]")
-
-        console.print("\n[bold]Why this matters:[/bold]")
-        console.print("  • The .env file stores your credentials and settings")
-        console.print("  • PROXY_API_KEY protects your proxy from unauthorized access")
-        console.print("  • Provider API keys enable LLM access")
-
-        console.print("\n[bold]What happens next:[/bold]")
-        console.print("  1. We'll create a .env file with PROXY_API_KEY")
-        console.print("  2. You can add LLM provider credentials (API keys or OAuth)")
-        console.print("  3. The proxy will then start normally")
-
-        console.print(
-            "\n[bold yellow]:warning:  Note:[/bold yellow] The credential tool adds PROXY_API_KEY by default."
-        )
-        console.print("   You can remove it later if you want an unsecured proxy.\n")
-
-        console.input(
-            "[bold green]Press Enter to launch the credential setup tool...[/bold green]"
+        _console.print("[bold yellow]:warning:  Configuration Required[/bold yellow]\n")
+        _console.print("The proxy needs initial configuration:")
+        _console.print("  [red]:x: No .env file found[/red]")
+        _console.print("\n[bold]What happens next:[/bold]")
+        _console.print("  1. We'll create a .env file with PROXY_API_KEY")
+        _console.print("  2. You can add LLM provider credentials")
+        _console.print("  3. The proxy will then start normally")
+        _console.input(
+            "\n[bold green]Press Enter to launch the credential setup tool...[/bold green]"
         )
 
-    # Check if user explicitly wants to add credentials
-    if args.add_credential:
-        # Import and call ensure_env_defaults to create .env and PROXY_API_KEY if needed
-        from rotator_library.credential_tool import ensure_env_defaults
+    # Check onboarding
+    if needs_onboarding():
+        show_onboarding_message()
+        from rotator_library.credential_tool import ensure_env_defaults, run_credential_tool
 
         ensure_env_defaults()
-        # Reload environment variables after ensure_env_defaults creates/updates .env
         load_dotenv(ENV_FILE, override=True)
         run_credential_tool()
-    else:
-        # Check if onboarding is needed
+        load_dotenv(ENV_FILE, override=True)
+
         if needs_onboarding():
-            # Import console from rich for better messaging
-            from rich.console import Console
-            from rich.panel import Panel
+            _console.print("\n[bold red]:x: Configuration incomplete.[/bold red]")
+            sys.exit(1)
+        else:
+            _console.print("\n[bold green]:white_check_mark: Configuration complete![/bold green]")
 
-            console = Console()
-
-            # Show clear explanatory message
-            show_onboarding_message()
-
-            # Launch credential tool automatically
-            from rotator_library.credential_tool import ensure_env_defaults
-
-            ensure_env_defaults()
-            load_dotenv(ENV_FILE, override=True)
-            run_credential_tool()
-
-            # After credential tool exits, reload and re-check
-            load_dotenv(ENV_FILE, override=True)
-            # Re-read PROXY_API_KEY from environment
-            PROXY_API_KEY = os.getenv("PROXY_API_KEY")
-
-            # Verify onboarding is complete
-            if needs_onboarding():
-                console.print("\n[bold red]:x: Configuration incomplete.[/bold red]")
-                console.print(
-                    "The proxy still cannot start. Please ensure PROXY_API_KEY is set in .env\n"
-                )
-                sys.exit(1)
-            else:
-                console.print(
-                    "\n[bold green]:white_check_mark: Configuration complete![/bold green]"
-                )
-                console.print("\nStarting proxy server...\n")
-
-        import uvicorn
-
-        uvicorn.run(app, host=args.host, port=args.port)
+    uvicorn.run(app, host=args.host, port=args.port)

--- a/src/proxy_app/models.py
+++ b/src/proxy_app/models.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Mirrowel
+
+"""
+Pydantic models for the proxy application.
+
+This module contains all request/response models used by the API endpoints.
+"""
+
+import time
+from typing import List, Optional, Union
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class EmbeddingRequest(BaseModel):
+    """Request model for embedding endpoint."""
+    model: str
+    input: Union[str, List[str]]
+    input_type: Optional[str] = None
+    dimensions: Optional[int] = None
+    user: Optional[str] = None
+
+
+class ModelCard(BaseModel):
+    """Basic model card for minimal response."""
+    id: str
+    object: str = "model"
+    created: int = Field(default_factory=lambda: int(time.time()))
+    owned_by: str = "Mirro-Proxy"
+
+
+class ModelCapabilities(BaseModel):
+    """Model capability flags."""
+    tool_choice: bool = False
+    function_calling: bool = False
+    reasoning: bool = False
+    vision: bool = False
+    system_messages: bool = True
+    prompt_caching: bool = False
+    assistant_prefill: bool = False
+
+
+class EnrichedModelCard(BaseModel):
+    """Extended model card with pricing and capabilities."""
+    id: str
+    object: str = "model"
+    created: int = Field(default_factory=lambda: int(time.time()))
+    owned_by: str = "unknown"
+    # Pricing (optional - may not be available for all models)
+    input_cost_per_token: Optional[float] = None
+    output_cost_per_token: Optional[float] = None
+    cache_read_input_token_cost: Optional[float] = None
+    cache_creation_input_token_cost: Optional[float] = None
+    # Limits (optional)
+    max_input_tokens: Optional[int] = None
+    max_output_tokens: Optional[int] = None
+    context_window: Optional[int] = None
+    # Capabilities
+    mode: str = "chat"
+    supported_modalities: List[str] = Field(default_factory=lambda: ["text"])
+    supported_output_modalities: List[str] = Field(default_factory=lambda: ["text"])
+    capabilities: Optional[ModelCapabilities] = None
+    # Debug info (optional)
+    _sources: Optional[List[str]] = None
+    _match_type: Optional[str] = None
+
+    model_config = ConfigDict(extra="allow")  # Allow extra fields from the service
+
+
+class ModelList(BaseModel):
+    """List of models response."""
+    object: str = "list"
+    data: List[ModelCard]
+
+
+class EnrichedModelList(BaseModel):
+    """List of enriched models with pricing and capabilities."""
+    object: str = "list"
+    data: List[EnrichedModelCard]
+
+
+class CostEstimateRequest(BaseModel):
+    """Request model for cost estimation endpoint."""
+    model: str
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+
+
+class CostEstimateResponse(BaseModel):
+    """Response model for cost estimation endpoint."""
+    model: str
+    cost: Optional[float] = None
+    currency: str = "USD"
+    pricing: dict = Field(default_factory=dict)
+    source: Optional[str] = None
+
+
+class TokenCountRequest(BaseModel):
+    """Request model for token count endpoint."""
+    model: str
+    messages: List[dict]
+
+
+class RefreshQuotaStatsRequest(BaseModel):
+    """Request model for quota stats refresh endpoint."""
+    action: str = "reload"  # "reload" or "force_refresh"
+    scope: str = "all"  # "all", "provider", or "credential"
+    provider: Optional[str] = None
+    credential: Optional[str] = None

--- a/src/proxy_app/routes/__init__.py
+++ b/src/proxy_app/routes/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Mirrowel
+
+"""Route modules for the proxy application."""

--- a/src/proxy_app/routes/admin.py
+++ b/src/proxy_app/routes/admin.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Mirrowel
+
+"""
+Admin and utility API routes.
+
+This module contains administrative endpoints including:
+- Quota stats (/v1/quota-stats)
+- Provider list (/v1/providers)
+- Model info stats (/v1/model-info/stats)
+"""
+
+import logging
+import time
+from typing import Optional
+
+from fastapi import APIRouter, Request, HTTPException, Depends
+
+from rotator_library import RotatingClient
+
+from proxy_app.dependencies import (
+    get_rotating_client,
+    get_model_info_service,
+    verify_api_key,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.get("/v1/providers")
+async def list_providers(_=Depends(verify_api_key)):
+    """Returns a list of all available providers."""
+    from rotator_library.providers import PROVIDER_PLUGINS
+    return list(PROVIDER_PLUGINS.keys())
+
+
+@router.get("/v1/quota-stats")
+async def get_quota_stats(
+    request: Request,
+    client: RotatingClient = Depends(get_rotating_client),
+    _=Depends(verify_api_key),
+    provider: Optional[str] = None,
+):
+    """
+    Returns quota and usage statistics for all credentials.
+
+    This returns cached data from the proxy without making external API calls.
+    Use POST to reload from disk or force refresh from external APIs.
+    """
+    try:
+        stats = await client.get_quota_stats(provider_filter=provider)
+        return stats
+    except Exception as e:
+        logger.error(f"Failed to get quota stats: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/v1/quota-stats")
+async def refresh_quota_stats(
+    request: Request,
+    client: RotatingClient = Depends(get_rotating_client),
+    _=Depends(verify_api_key),
+):
+    """
+    Refresh quota and usage statistics.
+
+    Request body:
+        {
+            "action": "reload" | "force_refresh",
+            "scope": "all" | "provider" | "credential",
+            "provider": "antigravity",
+            "credential": "antigravity_oauth_1.json"
+        }
+    """
+    try:
+        data = await request.json()
+        action = data.get("action", "reload")
+        scope = data.get("scope", "all")
+        provider = data.get("provider")
+        credential = data.get("credential")
+
+        # Validate parameters
+        if action not in ("reload", "force_refresh"):
+            raise HTTPException(
+                status_code=400,
+                detail="action must be 'reload' or 'force_refresh'",
+            )
+
+        if scope not in ("all", "provider", "credential"):
+            raise HTTPException(
+                status_code=400,
+                detail="scope must be 'all', 'provider', or 'credential'",
+            )
+
+        if scope in ("provider", "credential") and not provider:
+            raise HTTPException(
+                status_code=400,
+                detail="'provider' is required when scope is 'provider' or 'credential'",
+            )
+
+        if scope == "credential" and not credential:
+            raise HTTPException(
+                status_code=400,
+                detail="'credential' is required when scope is 'credential'",
+            )
+
+        refresh_result = {
+            "action": action,
+            "scope": scope,
+            "provider": provider,
+            "credential": credential,
+        }
+
+        if action == "reload":
+            # Just reload from disk
+            start_time = time.time()
+            await client.reload_usage_from_disk()
+            refresh_result["duration_ms"] = int((time.time() - start_time) * 1000)
+            refresh_result["success"] = True
+            refresh_result["message"] = "Reloaded usage data from disk"
+
+        elif action == "force_refresh":
+            # Force refresh from external API
+            result = await client.force_refresh_quota(
+                provider=provider if scope in ("provider", "credential") else None,
+                credential=credential if scope == "credential" else None,
+            )
+            refresh_result.update(result)
+            refresh_result["success"] = result["failed_count"] == 0
+
+        # Get updated stats
+        stats = await client.get_quota_stats(provider_filter=provider)
+        stats["refresh_result"] = refresh_result
+        stats["data_source"] = "refreshed"
+
+        return stats
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to refresh quota stats: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/v1/model-info/stats")
+async def model_info_stats(
+    request: Request,
+    _=Depends(verify_api_key),
+):
+    """Returns statistics about the model info service (for monitoring/debugging)."""
+    model_info_service = get_model_info_service(request)
+    if model_info_service:
+        return model_info_service.get_stats()
+    return {"error": "Model info service not initialized"}

--- a/src/proxy_app/routes/anthropic.py
+++ b/src/proxy_app/routes/anthropic.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Mirrowel
+
+"""
+Anthropic-compatible API routes.
+
+This module contains all Anthropic-compatible endpoints including:
+- Messages (/v1/messages)
+- Token count (/v1/messages/count_tokens)
+"""
+
+import logging
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, Request, HTTPException, Depends
+from fastapi.responses import StreamingResponse, JSONResponse
+
+from rotator_library import RotatingClient
+from rotator_library.anthropic_compat import (
+    AnthropicMessagesRequest,
+    AnthropicCountTokensRequest,
+)
+
+from proxy_app.dependencies import (
+    get_rotating_client,
+    verify_anthropic_api_key,
+)
+from proxy_app.detailed_logger import RawIOLogger
+from proxy_app.request_logger import log_request_to_console
+from proxy_app.error_mapping import map_litellm_error_to_anthropic
+
+import os
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+ENABLE_RAW_LOGGING = os.getenv("ENABLE_RAW_LOGGING", "false").lower() == "true"
+
+
+@router.post("/v1/messages")
+async def anthropic_messages(
+    request: Request,
+    body: AnthropicMessagesRequest,
+    client: RotatingClient = Depends(get_rotating_client),
+    _=Depends(verify_anthropic_api_key),
+):
+    """
+    Anthropic-compatible Messages API endpoint.
+
+    Accepts requests in Anthropic's format and returns responses in Anthropic's format.
+    Internally translates to OpenAI format for processing via LiteLLM.
+    """
+    raw_logger = RawIOLogger() if ENABLE_RAW_LOGGING else None
+
+    # Log raw Anthropic request if raw logging is enabled
+    if raw_logger:
+        raw_logger.log_request(
+            headers=dict(request.headers),
+            body=body.model_dump(exclude_none=True),
+        )
+
+    try:
+        # Log the request to console
+        log_request_to_console(
+            url=str(request.url),
+            headers=dict(request.headers),
+            client_info=(
+                request.client.host if request.client else "unknown",
+                request.client.port if request.client else 0,
+            ),
+            request_data=body.model_dump(exclude_none=True),
+        )
+
+        # Use the library method to handle the request
+        result = await client.anthropic_messages(body, raw_request=request)
+
+        if body.stream:
+            # Streaming response
+            return StreamingResponse(
+                result,
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                    "X-Accel-Buffering": "no",
+                },
+            )
+        else:
+            # Non-streaming response
+            if raw_logger:
+                raw_logger.log_final_response(
+                    status_code=200,
+                    headers=None,
+                    body=result,
+                )
+            return JSONResponse(content=result)
+
+    except Exception as e:
+        logger.error(f"Anthropic messages endpoint error: {e}")
+        if raw_logger:
+            raw_logger.log_final_response(
+                status_code=500,
+                headers=None,
+                body={"error": str(e)},
+            )
+        raise map_litellm_error_to_anthropic(e, "anthropic_messages")
+
+
+@router.post("/v1/messages/count_tokens")
+async def anthropic_count_tokens(
+    request: Request,
+    body: AnthropicCountTokensRequest,
+    client: RotatingClient = Depends(get_rotating_client),
+    _=Depends(verify_anthropic_api_key),
+):
+    """
+    Anthropic-compatible count_tokens endpoint.
+
+    Counts the number of tokens that would be used by a Messages API request.
+    """
+    try:
+        # Use the library method to handle the request
+        result = await client.anthropic_count_tokens(body)
+        return JSONResponse(content=result)
+
+    except Exception as e:
+        logger.error(f"Anthropic count_tokens endpoint error: {e}")
+        raise map_litellm_error_to_anthropic(e, "anthropic_count_tokens")

--- a/src/proxy_app/routes/openai.py
+++ b/src/proxy_app/routes/openai.py
@@ -1,0 +1,354 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Mirrowel
+
+"""
+OpenAI-compatible API routes.
+
+This module contains all OpenAI-compatible endpoints including:
+- Chat completions (/v1/chat/completions)
+- Embeddings (/v1/embeddings)
+- Models list (/v1/models)
+- Token count (/v1/token-count)
+- Cost estimate (/v1/cost-estimate)
+"""
+
+import asyncio
+import json
+import logging
+import os
+import time
+from typing import Optional
+
+from fastapi import APIRouter, Request, HTTPException, Depends, Query
+from fastapi.responses import StreamingResponse, JSONResponse
+
+import litellm
+from rotator_library import RotatingClient
+
+from proxy_app.dependencies import (
+    get_rotating_client,
+    get_embedding_batcher,
+    get_model_info_service,
+    verify_api_key,
+)
+from proxy_app.models import EmbeddingRequest
+from proxy_app.streaming import streaming_response_wrapper
+from proxy_app.detailed_logger import RawIOLogger
+from proxy_app.request_logger import log_request_to_console
+from proxy_app.error_mapping import map_litellm_error
+from proxy_app.batch_manager import EmbeddingBatcher
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+# Configuration from environment
+ENABLE_RAW_LOGGING = os.getenv("ENABLE_RAW_LOGGING", "false").lower() == "true"
+ENABLE_REQUEST_LOGGING = os.getenv("ENABLE_REQUEST_LOGGING", "false").lower() == "true"
+
+
+@router.post("/v1/chat/completions")
+async def chat_completions(
+    request: Request,
+    client: RotatingClient = Depends(get_rotating_client),
+    _=Depends(verify_api_key),
+):
+    """
+    OpenAI-compatible chat completions endpoint.
+    Handles both streaming and non-streaming responses.
+    """
+    raw_logger = RawIOLogger() if ENABLE_RAW_LOGGING else None
+
+    try:
+        # Read and parse the request body
+        try:
+            request_data = await request.json()
+        except json.JSONDecodeError:
+            raise HTTPException(status_code=400, detail="Invalid JSON in request body.")
+
+        # Global temperature=0 override
+        override_temp_zero = os.getenv("OVERRIDE_TEMPERATURE_ZERO", "false").lower()
+        if (
+            override_temp_zero in ("remove", "set", "true", "1", "yes")
+            and "temperature" in request_data
+            and request_data["temperature"] == 0
+        ):
+            if override_temp_zero == "remove":
+                del request_data["temperature"]
+                logger.debug("OVERRIDE_TEMPERATURE_ZERO=remove: Removed temperature=0")
+            else:
+                request_data["temperature"] = 1.0
+                logger.debug("OVERRIDE_TEMPERATURE_ZERO=set: Changed temperature to 1.0")
+
+        # Raw logging
+        if raw_logger:
+            raw_logger.log_request(headers=request.headers, body=request_data)
+
+        # Log request
+        log_request_to_console(
+            url=str(request.url),
+            headers=dict(request.headers),
+            client_info=(request.client.host, request.client.port),
+            request_data=request_data,
+        )
+
+        is_streaming = request_data.get("stream", False)
+
+        if is_streaming:
+            response_generator = await client.acompletion(
+                request=request, **request_data
+            )
+            return StreamingResponse(
+                streaming_response_wrapper(
+                    request, request_data, response_generator, raw_logger
+                ),
+                media_type="text/event-stream",
+            )
+        else:
+            response = await client.acompletion(request=request, **request_data)
+            if raw_logger:
+                response_headers = (
+                    response.headers if hasattr(response, "headers") else None
+                )
+                status_code = (
+                    response.status_code if hasattr(response, "status_code") else 200
+                )
+                raw_logger.log_final_response(
+                    status_code=status_code,
+                    headers=response_headers,
+                    body=response.model_dump() if hasattr(response, "model_dump") else response,
+                )
+            return response
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise map_litellm_error(e, "chat_completions")
+
+
+@router.post("/v1/embeddings")
+async def embeddings(
+    request: Request,
+    body: EmbeddingRequest,
+    client: RotatingClient = Depends(get_rotating_client),
+    batcher: Optional[EmbeddingBatcher] = Depends(get_embedding_batcher),
+    _=Depends(verify_api_key),
+):
+    """
+    OpenAI-compatible embeddings endpoint.
+    Supports batched and direct pass-through modes.
+    """
+    try:
+        request_data = body.model_dump(exclude_none=True)
+        log_request_to_console(
+            url=str(request.url),
+            headers=dict(request.headers),
+            client_info=(request.client.host, request.client.port),
+            request_data=request_data,
+        )
+
+        USE_EMBEDDING_BATCHER = os.getenv("USE_EMBEDDING_BATCHER", "false").lower() == "true"
+
+        if USE_EMBEDDING_BATCHER and batcher:
+            # Server-side batching mode
+            inputs = request_data.get("input", [])
+            if isinstance(inputs, str):
+                inputs = [inputs]
+
+            tasks = []
+            for single_input in inputs:
+                individual_request = request_data.copy()
+                individual_request["input"] = single_input
+                tasks.append(batcher.add_request(individual_request))
+
+            results = await asyncio.gather(*tasks)
+
+            all_data = []
+            batch_usage = None
+            for i, result in enumerate(results):
+                result["data"][0]["index"] = i
+                all_data.extend(result["data"])
+                if i == 0 and result.get("usage"):
+                    batch_usage = result["usage"]
+
+            # Use batch usage or estimate
+            if batch_usage:
+                final_usage = batch_usage
+            else:
+                estimated_tokens = sum(len(str(inp)) // 4 for inp in inputs)
+                final_usage = {
+                    "prompt_tokens": estimated_tokens,
+                    "total_tokens": estimated_tokens,
+                }
+
+            final_response_data = {
+                "object": "list",
+                "model": results[0]["model"],
+                "data": all_data,
+                "usage": final_usage,
+            }
+            response = litellm.EmbeddingResponse(**final_response_data)
+        else:
+            # Direct pass-through mode
+            if isinstance(request_data.get("input"), str):
+                request_data["input"] = [request_data["input"]]
+            response = await client.aembedding(request=request, **request_data)
+
+        return response
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise map_litellm_error(e, "embeddings")
+
+
+@router.get("/v1/models")
+async def list_models(
+    request: Request,
+    client: RotatingClient = Depends(get_rotating_client),
+    _=Depends(verify_api_key),
+    enriched: bool = True,
+):
+    """Returns a list of available models in OpenAI-compatible format."""
+    model_ids = await client.get_all_available_models(grouped=False)
+
+    model_info_service = get_model_info_service(request)
+    if enriched and model_info_service and model_info_service.is_ready:
+        enriched_data = model_info_service.enrich_model_list(model_ids)
+        return {"object": "list", "data": enriched_data}
+
+    # Fallback to basic model cards
+    model_cards = [
+        {
+            "id": model_id,
+            "object": "model",
+            "created": int(time.time()),
+            "owned_by": "Mirro-Proxy",
+        }
+        for model_id in model_ids
+    ]
+    return {"object": "list", "data": model_cards}
+
+
+@router.get("/v1/models/{model_id:path}")
+async def get_model(
+    model_id: str,
+    request: Request,
+    _=Depends(verify_api_key),
+):
+    """Returns detailed information about a specific model."""
+    model_info_service = get_model_info_service(request)
+    if model_info_service and model_info_service.is_ready:
+        info = model_info_service.get_model_info(model_id)
+        if info:
+            return info.to_dict()
+
+    # Return basic info
+    return {
+        "id": model_id,
+        "object": "model",
+        "created": int(time.time()),
+        "owned_by": model_id.split("/")[0] if "/" in model_id else "unknown",
+    }
+
+
+@router.post("/v1/token-count")
+async def token_count(
+    request: Request,
+    client: RotatingClient = Depends(get_rotating_client),
+    _=Depends(verify_api_key),
+):
+    """Calculates the token count for a given list of messages and a model."""
+    try:
+        data = await request.json()
+        model = data.get("model")
+        messages = data.get("messages")
+
+        if not model or not messages:
+            raise HTTPException(
+                status_code=400, detail="'model' and 'messages' are required."
+            )
+
+        count = client.token_count(**data)
+        return {"token_count": count}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Token count failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/v1/cost-estimate")
+async def cost_estimate(request: Request, _=Depends(verify_api_key)):
+    """
+    Estimates the cost for a request based on token counts and model pricing.
+    """
+    try:
+        data = await request.json()
+        model = data.get("model")
+        prompt_tokens = data.get("prompt_tokens", 0)
+        completion_tokens = data.get("completion_tokens", 0)
+        cache_read_tokens = data.get("cache_read_tokens", 0)
+        cache_creation_tokens = data.get("cache_creation_tokens", 0)
+
+        if not model:
+            raise HTTPException(status_code=400, detail="'model' is required.")
+
+        result = {
+            "model": model,
+            "cost": None,
+            "currency": "USD",
+            "pricing": {},
+            "source": None,
+        }
+
+        # Try model info service first
+        model_info_service = get_model_info_service(request)
+        if model_info_service and model_info_service.is_ready:
+            cost = model_info_service.calculate_cost(
+                model,
+                prompt_tokens,
+                completion_tokens,
+                cache_read_tokens,
+                cache_creation_tokens,
+            )
+            if cost is not None:
+                cost_info = model_info_service.get_cost_info(model)
+                result["cost"] = cost
+                result["pricing"] = cost_info or {}
+                result["source"] = "model_info_service"
+                return result
+
+        # Fallback to litellm
+        try:
+            model_info = litellm.get_model_info(model)
+            input_cost = model_info.get("input_cost_per_token", 0)
+            output_cost = model_info.get("output_cost_per_token", 0)
+
+            if input_cost or output_cost:
+                cost = (prompt_tokens * input_cost) + (completion_tokens * output_cost)
+                result["cost"] = cost
+                result["pricing"] = {
+                    "input_cost_per_token": input_cost,
+                    "output_cost_per_token": output_cost,
+                }
+                result["source"] = "litellm_fallback"
+                return result
+        except Exception:
+            pass
+
+        result["source"] = "unknown"
+        result["error"] = "Pricing data not available for this model"
+        return result
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Cost estimate failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/")
+def read_root():
+    """Root endpoint returning proxy status."""
+    return {"Status": "API Key Proxy is running"}

--- a/src/proxy_app/settings_tool.py
+++ b/src/proxy_app/settings_tool.py
@@ -45,6 +45,13 @@ try:
 except ImportError:
     IFLOW_DEFAULT_OAUTH_PORT = 11451
 
+try:
+    from rotator_library.providers.openai_codex_auth_base import OpenAICodexAuthBase
+
+    OPENAI_CODEX_DEFAULT_OAUTH_PORT = OpenAICodexAuthBase.CALLBACK_PORT
+except ImportError:
+    OPENAI_CODEX_DEFAULT_OAUTH_PORT = 1455
+
 
 def clear_screen(subtitle: str = ""):
     """
@@ -553,11 +560,21 @@ IFLOW_SETTINGS = {
     },
 }
 
+# OpenAI Codex provider environment variables
+OPENAI_CODEX_SETTINGS = {
+    "OPENAI_CODEX_OAUTH_PORT": {
+        "type": "int",
+        "default": OPENAI_CODEX_DEFAULT_OAUTH_PORT,
+        "description": "Local port for OAuth callback server during authentication",
+    },
+}
+
 # Map provider names to their settings definitions
 PROVIDER_SETTINGS_MAP = {
     "antigravity": ANTIGRAVITY_SETTINGS,
     "gemini_cli": GEMINI_CLI_SETTINGS,
     "iflow": IFLOW_SETTINGS,
+    "openai_codex": OPENAI_CODEX_SETTINGS,
 }
 
 

--- a/src/proxy_app/startup.py
+++ b/src/proxy_app/startup.py
@@ -1,0 +1,328 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Mirrowel
+
+"""
+Application startup and shutdown logic.
+
+This module contains the lifespan context manager and initialization
+code for the FastAPI application.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import time
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from fastapi import FastAPI
+
+from rotator_library import RotatingClient, PROVIDER_PLUGINS
+from rotator_library.credential_manager import CredentialManager
+from rotator_library.background_refresher import BackgroundRefresher
+from rotator_library.model_info_service import init_model_info_service
+from proxy_app.batch_manager import EmbeddingBatcher
+
+logger = logging.getLogger(__name__)
+
+
+def _mask_api_key(key: str) -> str:
+    """Mask API key for safe display in logs. Shows first 4 and last 4 chars."""
+    if not key or len(key) <= 8:
+        return "****"
+    return f"{key[:4]}****{key[-4:]}"
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI, data_dir: Optional[Path] = None):
+    """
+    Manage the RotatingClient's lifecycle with the app's lifespan.
+
+    Args:
+        app: The FastAPI application instance
+        data_dir: Optional data directory path
+    """
+    from rotator_library.utils.paths import get_default_root
+
+    root_dir = data_dir or get_default_root()
+
+    # Perform skippable OAuth initialization at startup
+    skip_oauth_init = os.getenv("SKIP_OAUTH_INIT_CHECK", "false").lower() == "true"
+
+    # Credential discovery
+    cred_manager = CredentialManager(os.environ)
+    oauth_credentials = cred_manager.discover_and_prepare()
+
+    if not skip_oauth_init and oauth_credentials:
+        oauth_credentials = await _process_oauth_credentials(oauth_credentials)
+
+    # Load provider-specific params
+    litellm_provider_params = {
+        "gemini_cli": {"project_id": os.getenv("GEMINI_CLI_PROJECT_ID")}
+    }
+
+    # Load global timeout
+    global_timeout = int(os.getenv("GLOBAL_TIMEOUT", "30"))
+
+    # Build API keys dict
+    api_keys = _discover_api_keys()
+
+    # Load model filters
+    ignore_models = _load_model_filters("IGNORE_MODELS_")
+    whitelist_models = _load_model_filters("WHITELIST_MODELS_")
+
+    # Load max concurrent per key
+    max_concurrent = _load_max_concurrent()
+
+    # Initialize client
+    client = RotatingClient(
+        api_keys=api_keys,
+        oauth_credentials=oauth_credentials,
+        configure_logging=True,
+        global_timeout=global_timeout,
+        litellm_provider_params=litellm_provider_params,
+        ignore_models=ignore_models,
+        whitelist_models=whitelist_models,
+        enable_request_logging=os.getenv("ENABLE_REQUEST_LOGGING", "false").lower() == "true",
+        max_concurrent_requests_per_key=max_concurrent,
+    )
+
+    await client.initialize_usage_managers()
+
+    # Start background refresher
+    client.background_refresher.start()
+    app.state.rotating_client = client
+
+    # Warn if no credentials
+    if not client.all_credentials:
+        logging.warning("=" * 70)
+        logging.warning("⚠️  NO PROVIDER CREDENTIALS CONFIGURED")
+        logging.warning("The proxy is running but cannot serve any LLM requests.")
+        logging.warning("Launch the credential tool to add API keys or OAuth credentials.")
+        logging.warning("  • Executable: Run with --add-credential flag")
+        logging.warning("  • Source: python src/proxy_app/main.py --add-credential")
+        logging.warning("=" * 70)
+
+    # Initialize embedding batcher
+    USE_EMBEDDING_BATCHER = os.getenv("USE_EMBEDDING_BATCHER", "false").lower() == "true"
+    if USE_EMBEDDING_BATCHER:
+        batcher = EmbeddingBatcher(client=client)
+        app.state.embedding_batcher = batcher
+        logging.info("RotatingClient and EmbeddingBatcher initialized.")
+    else:
+        app.state.embedding_batcher = None
+        logging.info("RotatingClient initialized (EmbeddingBatcher disabled).")
+
+    # Start model info service
+    model_info_service = await init_model_info_service()
+    app.state.model_info_service = model_info_service
+    logging.info("Model info service started (fetching pricing data in background).")
+
+    yield
+
+    # Shutdown
+    await client.background_refresher.stop()
+    if app.state.embedding_batcher:
+        await app.state.embedding_batcher.stop()
+    await client.close()
+
+    if app.state.embedding_batcher:
+        logging.info("RotatingClient and EmbeddingBatcher closed.")
+    else:
+        logging.info("RotatingClient closed.")
+
+    # Stop model info service
+    if hasattr(app.state, "model_info_service") and app.state.model_info_service:
+        await app.state.model_info_service.stop()
+
+
+async def _process_oauth_credentials(
+    oauth_credentials: Dict[str, List[str]],
+) -> Dict[str, List[str]]:
+    """Process OAuth credentials with deduplication."""
+    processed_emails: Dict[str, Dict[str, str]] = {}
+    credentials_to_initialize: Dict[str, List[str]] = {}
+    final_oauth_credentials: Dict[str, List[str]] = {}
+
+    logging.info("Starting OAuth credential validation and deduplication...")
+
+    # Pass 1: Pre-scan for duplicates
+    for provider, paths in oauth_credentials.items():
+        if provider not in credentials_to_initialize:
+            credentials_to_initialize[provider] = []
+        for path in paths:
+            if path.startswith("env://"):
+                credentials_to_initialize[provider].append(path)
+                continue
+
+            email, _ = await _read_credential_metadata(path)
+
+            if email:
+                if email not in processed_emails:
+                    processed_emails[email] = {}
+
+                if provider in processed_emails[email]:
+                    original_path = processed_emails[email][provider]
+                    logging.warning(
+                        f"Duplicate for '{email}' on '{provider}' found in pre-scan: "
+                        f"'{Path(path).name}'. Original: '{Path(original_path).name}'. Skipping."
+                    )
+                    continue
+                else:
+                    processed_emails[email][provider] = path
+                credentials_to_initialize[provider].append(path)
+            elif email is None:
+                logging.warning(
+                    f"Could not pre-read metadata from '{path}'. Will process during initialization."
+                )
+                credentials_to_initialize[provider].append(path)
+
+    # Pass 2: Parallel initialization
+    async def process_credential(provider: str, path: str, provider_instance):
+        """Process a single credential: initialize and fetch user info."""
+        try:
+            await provider_instance.initialize_token(path)
+
+            if not hasattr(provider_instance, "get_user_info"):
+                return (provider, path, None, None)
+
+            user_info = await provider_instance.get_user_info(path)
+            email = user_info.get("email")
+            return (provider, path, email, None)
+
+        except Exception as e:
+            logging.error(f"Failed to process OAuth token for {provider} at '{path}': {e}")
+            return (provider, path, None, e)
+
+    tasks = []
+    for provider, paths in credentials_to_initialize.items():
+        if not paths:
+            continue
+
+        provider_plugin_class = PROVIDER_PLUGINS.get(provider)
+        if not provider_plugin_class:
+            continue
+
+        provider_instance = provider_plugin_class()
+
+        for path in paths:
+            tasks.append(process_credential(provider, path, provider_instance))
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    # Pass 3: Sequential deduplication and final assembly
+    for result in results:
+        if isinstance(result, Exception):
+            logging.error(f"Credential processing raised exception: {result}")
+            continue
+
+        provider, path, email, error = result
+
+        if error:
+            continue
+
+        if email is None:
+            if provider not in final_oauth_credentials:
+                final_oauth_credentials[provider] = []
+            final_oauth_credentials[provider].append(path)
+            continue
+
+        if not email:
+            logging.warning(f"Could not retrieve email for '{path}'. Treating as unique.")
+            if provider not in final_oauth_credentials:
+                final_oauth_credentials[provider] = []
+            final_oauth_credentials[provider].append(path)
+            continue
+
+        # Deduplication check
+        if email not in processed_emails:
+            processed_emails[email] = {}
+
+        if provider in processed_emails[email] and processed_emails[email][provider] != path:
+            original_path = processed_emails[email][provider]
+            logging.warning(
+                f"Duplicate for '{email}' on '{provider}' found post-init: "
+                f"'{Path(path).name}'. Original: '{Path(original_path).name}'. Skipping."
+            )
+            continue
+        else:
+            processed_emails[email][provider] = path
+            if provider not in final_oauth_credentials:
+                final_oauth_credentials[provider] = []
+            final_oauth_credentials[provider].append(path)
+
+            # Update metadata
+            if not path.startswith("env://"):
+                await _update_metadata_file(path, email)
+
+    logging.info("OAuth credential processing complete.")
+    return final_oauth_credentials
+
+
+async def _read_credential_metadata(path: str) -> tuple:
+    """Read credential file and extract email from metadata."""
+    try:
+        def _read_file():
+            with open(path, "r") as f:
+                return json.load(f)
+        data = await asyncio.to_thread(_read_file)
+        metadata = data.get("_proxy_metadata", {})
+        return metadata.get("email"), data
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None, None
+
+
+async def _update_metadata_file(path: str, email: str):
+    """Update credential metadata file with email and timestamp."""
+    try:
+        def _do_update():
+            with open(path, "r+") as f:
+                data = json.load(f)
+                metadata = data.get("_proxy_metadata", {})
+                metadata["email"] = email
+                metadata["last_check_timestamp"] = time.time()
+                data["_proxy_metadata"] = metadata
+                f.seek(0)
+                json.dump(data, f, indent=2)
+                f.truncate()
+        await asyncio.to_thread(_do_update)
+    except Exception as e:
+        logging.error(f"Failed to update metadata for '{path}': {e}")
+
+
+def _discover_api_keys() -> Dict[str, List[str]]:
+    """Discover API keys from environment variables."""
+    api_keys = {}
+    for key, value in os.environ.items():
+        if "_API_KEY" in key and key != "PROXY_API_KEY":
+            provider = key.split("_API_KEY")[0].lower()
+            if provider not in api_keys:
+                api_keys[provider] = []
+            api_keys[provider].append(value)
+    return api_keys
+
+
+def _load_model_filters(prefix: str) -> Dict[str, List[str]]:
+    """Load model filters from environment variables."""
+    filters = {}
+    for key, value in os.environ.items():
+        if key.startswith(prefix):
+            provider = key.replace(prefix, "").lower()
+            models = [model.strip() for model in value.split(",") if model.strip()]
+            filters[provider] = models
+    return filters
+
+
+def _load_max_concurrent() -> Dict[str, int]:
+    """Load max concurrent requests per key from environment."""
+    max_concurrent = {}
+    for key, value in os.environ.items():
+        if key.startswith("MAX_CONCURRENT_REQUESTS_PER_KEY_"):
+            provider = key.replace("MAX_CONCURRENT_REQUESTS_PER_KEY_", "").lower()
+            try:
+                max_concurrent[provider] = max(1, int(value))
+            except ValueError:
+                logging.warning(f"Invalid max_concurrent for '{provider}': {value}")
+    return max_concurrent

--- a/src/proxy_app/streaming.py
+++ b/src/proxy_app/streaming.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Mirrowel
+
+"""
+Streaming response handling for the proxy application.
+
+This module provides the streaming_response_wrapper function and related utilities
+for handling SSE streams from LiteLLM.
+"""
+
+import json
+import logging
+from typing import AsyncGenerator, Optional, Any, Dict
+
+from fastapi import Request
+
+from proxy_app.detailed_logger import RawIOLogger
+
+logger = logging.getLogger(__name__)
+
+
+async def streaming_response_wrapper(
+    request: Request,
+    request_data: dict,
+    response_stream: AsyncGenerator[str, None],
+    logger_instance: Optional[RawIOLogger] = None,
+) -> AsyncGenerator[str, None]:
+    """
+    Wraps a streaming response to log the full response after completion
+    and ensures any errors during the stream are sent to the client.
+
+    When logger_instance is None, operates in lightweight passthrough mode without
+    accumulating or parsing chunks.
+    """
+    # Fast path: passthrough mode when no logger is provided
+    if logger_instance is None:
+        try:
+            async for chunk_str in response_stream:
+                if await request.is_disconnected():
+                    logger.warning("Client disconnected, stopping stream.")
+                    break
+                yield chunk_str
+        except Exception as e:
+            logger.error(f"An error occurred during the response stream: {e}")
+            # Yield a final error message to the client
+            error_payload = {
+                "error": {
+                    "message": f"An unexpected error occurred during the stream: {str(e)}",
+                    "type": "proxy_internal_error",
+                    "code": 500,
+                }
+            }
+            yield f"data: {json.dumps(error_payload)}\n\n"
+            yield "data: [DONE]\n\n"
+        return
+
+    # Full aggregation mode when logging is enabled
+    response_chunks = []
+    full_response = {}
+
+    try:
+        async for chunk_str in response_stream:
+            if await request.is_disconnected():
+                logger.warning("Client disconnected, stopping stream.")
+                break
+            yield chunk_str
+            if chunk_str.strip() and chunk_str.startswith("data:"):
+                content = chunk_str[len("data:") :].strip()
+                if content != "[DONE]":
+                    try:
+                        chunk_data = json.loads(content)
+                        response_chunks.append(chunk_data)
+                        logger_instance.log_stream_chunk(chunk_data)
+                    except json.JSONDecodeError:
+                        pass
+    except Exception as e:
+        logger.error(f"An error occurred during the response stream: {e}")
+        # Yield a final error message to the client
+        error_payload = {
+            "error": {
+                "message": f"An unexpected error occurred during the stream: {str(e)}",
+                "type": "proxy_internal_error",
+                "code": 500,
+            }
+        }
+        yield f"data: {json.dumps(error_payload)}\n\n"
+        yield "data: [DONE]\n\n"
+        # Also log this as a failed request
+        logger_instance.log_final_response(
+            status_code=500, headers=None, body={"error": str(e)}
+        )
+        return
+    finally:
+        if response_chunks:
+            full_response = _aggregate_streaming_chunks(response_chunks)
+
+            logger_instance.log_final_response(
+                status_code=200,
+                headers=None,
+                body=full_response,
+            )
+
+
+def _aggregate_streaming_chunks(chunks: list) -> dict:
+    """
+    Aggregate streaming chunks into a final response structure.
+
+    Args:
+        chunks: List of parsed chunk data
+
+    Returns:
+        Aggregated response dict
+    """
+    final_message = {"role": "assistant"}
+    aggregated_tool_calls: Dict[int, dict] = {}
+    usage_data = None
+    finish_reason = None
+
+    for chunk in chunks:
+        if "choices" in chunk and chunk["choices"]:
+            choice = chunk["choices"][0]
+            delta = choice.get("delta", {})
+
+            # Dynamically aggregate all fields from the delta
+            for key, value in delta.items():
+                if value is None:
+                    continue
+
+                if key == "content":
+                    if "content" not in final_message:
+                        final_message["content"] = ""
+                    if value:
+                        final_message["content"] += value
+
+                elif key == "tool_calls":
+                    for tc_chunk in value:
+                        index = tc_chunk["index"]
+                        if index not in aggregated_tool_calls:
+                            aggregated_tool_calls[index] = {
+                                "type": "function",
+                                "function": {"name": "", "arguments": ""},
+                            }
+                        # Ensure 'function' key exists
+                        if "function" not in aggregated_tool_calls[index]:
+                            aggregated_tool_calls[index]["function"] = {
+                                "name": "",
+                                "arguments": "",
+                            }
+                        if tc_chunk.get("id"):
+                            aggregated_tool_calls[index]["id"] = tc_chunk["id"]
+                        if "function" in tc_chunk:
+                            if "name" in tc_chunk["function"]:
+                                if tc_chunk["function"]["name"] is not None:
+                                    aggregated_tool_calls[index]["function"][
+                                        "name"
+                                    ] += tc_chunk["function"]["name"]
+                            if "arguments" in tc_chunk["function"]:
+                                if tc_chunk["function"]["arguments"] is not None:
+                                    aggregated_tool_calls[index]["function"][
+                                        "arguments"
+                                    ] += tc_chunk["function"]["arguments"]
+
+                elif key == "function_call":
+                    if "function_call" not in final_message:
+                        final_message["function_call"] = {"name": "", "arguments": ""}
+                    if "name" in value:
+                        if value["name"] is not None:
+                            final_message["function_call"]["name"] += value["name"]
+                    if "arguments" in value:
+                        if value["arguments"] is not None:
+                            final_message["function_call"]["arguments"] += value[
+                                "arguments"
+                            ]
+
+                else:  # Generic key handling
+                    if key == "role":
+                        final_message[key] = value
+                    elif key not in final_message:
+                        final_message[key] = value
+                    elif isinstance(final_message.get(key), str):
+                        final_message[key] += value
+                    else:
+                        final_message[key] = value
+
+            if "finish_reason" in choice and choice["finish_reason"]:
+                finish_reason = choice["finish_reason"]
+
+        if "usage" in chunk and chunk["usage"]:
+            usage_data = chunk["usage"]
+
+    # Final Response Construction
+    if aggregated_tool_calls:
+        final_message["tool_calls"] = list(aggregated_tool_calls.values())
+        # Override finish_reason when tool_calls exist
+        finish_reason = "tool_calls"
+
+    # Ensure standard fields are present
+    for field in ["content", "tool_calls", "function_call"]:
+        if field not in final_message:
+            final_message[field] = None
+
+    first_chunk = chunks[0]
+    final_choice = {
+        "index": 0,
+        "message": final_message,
+        "finish_reason": finish_reason,
+    }
+
+    return {
+        "id": first_chunk.get("id"),
+        "object": "chat.completion",
+        "created": first_chunk.get("created"),
+        "model": first_chunk.get("model"),
+        "choices": [final_choice],
+        "usage": usage_data,
+    }

--- a/src/rotator_library/credential_manager.py
+++ b/src/rotator_library/credential_manager.py
@@ -3,10 +3,13 @@
 
 import os
 import re
+import json
+import time
+import base64
 import shutil
 import logging
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Union
+from typing import Dict, List, Optional, Set, Union, Any, Tuple
 
 from .utils.paths import get_oauth_dir
 
@@ -18,6 +21,7 @@ DEFAULT_OAUTH_DIRS = {
     "qwen_code": Path.home() / ".qwen",
     "iflow": Path.home() / ".iflow",
     "antigravity": Path.home() / ".antigravity",
+    "openai_codex": Path.home() / ".codex",  # import source context only
     # Add other providers like 'claude' here if they have a standard CLI path
 }
 
@@ -28,6 +32,7 @@ ENV_OAUTH_PROVIDERS = {
     "antigravity": "ANTIGRAVITY",
     "qwen_code": "QWEN_CODE",
     "iflow": "IFLOW",
+    "openai_codex": "OPENAI_CODEX",
 }
 
 
@@ -120,6 +125,435 @@ class CredentialManager:
 
         return result
 
+    # -------------------------------------------------------------------------
+    # OpenAI Codex first-run import helpers
+    # -------------------------------------------------------------------------
+
+    def _decode_jwt_unverified(self, token: str) -> Optional[Dict[str, Any]]:
+        """Decode JWT payload without signature verification."""
+        if not token or not isinstance(token, str):
+            return None
+
+        parts = token.split(".")
+        if len(parts) < 2:
+            return None
+
+        payload = parts[1]
+        payload += "=" * (-len(payload) % 4)
+
+        try:
+            decoded = base64.urlsafe_b64decode(payload)
+            data = json.loads(decoded.decode("utf-8"))
+            return data if isinstance(data, dict) else None
+        except Exception:
+            return None
+
+    def _extract_codex_identity(self, access_token: str, id_token: Optional[str]) -> Tuple[Optional[str], Optional[str], Optional[int]]:
+        """
+        Extract (account_id, email, exp_ms) from Codex JWTs.
+
+        Priority:
+        - account_id: access_token -> id_token
+        - email: id_token -> access_token
+        - exp: access_token -> id_token
+        """
+
+        def extract_account(payload: Optional[Dict[str, Any]]) -> Optional[str]:
+            if not payload:
+                return None
+
+            direct = payload.get("https://api.openai.com/auth.chatgpt_account_id")
+            if isinstance(direct, str) and direct.strip():
+                return direct.strip()
+
+            auth_claim = payload.get("https://api.openai.com/auth")
+            if isinstance(auth_claim, dict):
+                nested = auth_claim.get("chatgpt_account_id")
+                if isinstance(nested, str) and nested.strip():
+                    return nested.strip()
+
+            orgs = payload.get("organizations")
+            if isinstance(orgs, list) and orgs:
+                first = orgs[0]
+                if isinstance(first, dict):
+                    org_id = first.get("id")
+                    if isinstance(org_id, str) and org_id.strip():
+                        return org_id.strip()
+
+            return None
+
+        def extract_email(payload: Optional[Dict[str, Any]]) -> Optional[str]:
+            if not payload:
+                return None
+            email = payload.get("email")
+            if isinstance(email, str) and email.strip():
+                return email.strip()
+            sub = payload.get("sub")
+            if isinstance(sub, str) and sub.strip():
+                return sub.strip()
+            return None
+
+        def extract_exp_ms(payload: Optional[Dict[str, Any]]) -> Optional[int]:
+            if not payload:
+                return None
+            exp = payload.get("exp")
+            if isinstance(exp, (int, float)):
+                return int(float(exp) * 1000)
+            return None
+
+        access_payload = self._decode_jwt_unverified(access_token)
+        id_payload = self._decode_jwt_unverified(id_token) if id_token else None
+
+        account_id = extract_account(access_payload) or extract_account(id_payload)
+        email = extract_email(id_payload) or extract_email(access_payload)
+        exp_ms = extract_exp_ms(access_payload) or extract_exp_ms(id_payload)
+
+        return account_id, email, exp_ms
+
+    def _normalize_openai_codex_auth_json_record(self, auth_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Normalize ~/.codex/auth.json format to proxy schema."""
+        tokens = auth_data.get("tokens")
+        if not isinstance(tokens, dict):
+            return None
+
+        access_token = tokens.get("access_token")
+        refresh_token = tokens.get("refresh_token")
+        id_token = tokens.get("id_token")
+
+        if not isinstance(access_token, str) or not isinstance(refresh_token, str):
+            return None
+
+        account_id, email, exp_ms = self._extract_codex_identity(access_token, id_token)
+
+        # Respect explicit account_id from source tokens if present
+        explicit_account = tokens.get("account_id")
+        if isinstance(explicit_account, str) and explicit_account.strip():
+            account_id = explicit_account.strip()
+
+        if exp_ms is None:
+            # conservative fallback to 5 minutes from now
+            exp_ms = int((time.time() + 300) * 1000)
+
+        return {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "id_token": id_token,
+            "expiry_date": exp_ms,
+            "token_uri": "https://auth.openai.com/oauth/token",
+            "_proxy_metadata": {
+                "email": email,
+                "account_id": account_id,
+                "last_check_timestamp": time.time(),
+                "loaded_from_env": False,
+                "env_credential_index": None,
+            },
+        }
+
+    def _normalize_openai_codex_accounts_record(self, account: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Normalize one ~/.codex-accounts.json account entry to proxy schema."""
+        access_token = account.get("access")
+        refresh_token = account.get("refresh")
+        id_token = account.get("idToken")
+
+        if not isinstance(access_token, str) or not isinstance(refresh_token, str):
+            return None
+
+        account_id, email, exp_ms = self._extract_codex_identity(access_token, id_token)
+
+        explicit_account = account.get("accountId")
+        if isinstance(explicit_account, str) and explicit_account.strip():
+            account_id = explicit_account.strip()
+
+        label = account.get("label")
+        if not email and isinstance(label, str) and label.strip():
+            email = label.strip()
+
+        expires = account.get("expires")
+        if isinstance(expires, (int, float)):
+            exp_ms = int(expires)
+
+        if exp_ms is None:
+            exp_ms = int((time.time() + 300) * 1000)
+
+        return {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "id_token": id_token,
+            "expiry_date": exp_ms,
+            "token_uri": "https://auth.openai.com/oauth/token",
+            "_proxy_metadata": {
+                "email": email,
+                "account_id": account_id,
+                "last_check_timestamp": time.time(),
+                "loaded_from_env": False,
+                "env_credential_index": None,
+            },
+        }
+
+    def _import_openai_codex_cli_credentials(
+        self,
+        auth_json_path: Optional[Path] = None,
+        accounts_json_path: Optional[Path] = None,
+    ) -> List[str]:
+        """
+        First-run import from Codex CLI stores into local oauth_creds/.
+
+        Source files are read-only:
+        - ~/.codex/auth.json (single account)
+        - ~/.codex-accounts.json (multi-account)
+        """
+        auth_json_path = auth_json_path or (Path.home() / ".codex" / "auth.json")
+        accounts_json_path = accounts_json_path or (Path.home() / ".codex-accounts.json")
+
+        normalized_records: List[Dict[str, Any]] = []
+
+        # Source 1: ~/.codex/auth.json
+        if auth_json_path.exists():
+            try:
+                with open(auth_json_path, "r") as f:
+                    auth_data = json.load(f)
+
+                if isinstance(auth_data, dict):
+                    record = self._normalize_openai_codex_auth_json_record(auth_data)
+                    if record:
+                        normalized_records.append(record)
+                    else:
+                        lib_logger.warning(
+                            "OpenAI Codex import: skipping malformed ~/.codex/auth.json record"
+                        )
+                else:
+                    lib_logger.warning(
+                        "OpenAI Codex import: ~/.codex/auth.json root is not an object"
+                    )
+            except Exception as e:
+                lib_logger.warning(
+                    f"OpenAI Codex import: failed to parse ~/.codex/auth.json: {e}"
+                )
+
+        # Source 2: ~/.codex-accounts.json
+        if accounts_json_path.exists():
+            try:
+                with open(accounts_json_path, "r") as f:
+                    accounts_data = json.load(f)
+
+                accounts = []
+                if isinstance(accounts_data, dict):
+                    raw_accounts = accounts_data.get("accounts")
+                    if isinstance(raw_accounts, list):
+                        accounts = raw_accounts
+                elif isinstance(accounts_data, list):
+                    accounts = accounts_data
+
+                if not accounts:
+                    lib_logger.warning(
+                        "OpenAI Codex import: ~/.codex-accounts.json has no accounts list"
+                    )
+
+                for idx, account in enumerate(accounts):
+                    if not isinstance(account, dict):
+                        lib_logger.warning(
+                            f"OpenAI Codex import: skipping malformed account entry #{idx + 1}"
+                        )
+                        continue
+
+                    record = self._normalize_openai_codex_accounts_record(account)
+                    if record:
+                        normalized_records.append(record)
+                    else:
+                        lib_logger.warning(
+                            f"OpenAI Codex import: skipping malformed account entry #{idx + 1}"
+                        )
+
+            except Exception as e:
+                lib_logger.warning(
+                    f"OpenAI Codex import: failed to parse ~/.codex-accounts.json: {e}"
+                )
+
+        if not normalized_records:
+            return []
+
+        # Deduplicate by account_id first, then email
+        unique: List[Dict[str, Any]] = []
+        seen_account_ids: Set[str] = set()
+        seen_emails: Set[str] = set()
+
+        for record in normalized_records:
+            metadata = record.get("_proxy_metadata", {})
+            account_id = metadata.get("account_id")
+            email = metadata.get("email")
+
+            if isinstance(account_id, str) and account_id:
+                if account_id in seen_account_ids:
+                    continue
+                seen_account_ids.add(account_id)
+
+            if isinstance(email, str) and email:
+                if email in seen_emails:
+                    continue
+                seen_emails.add(email)
+
+            unique.append(record)
+
+        imported_paths: List[str] = []
+        for i, record in enumerate(unique, 1):
+            local_path = self.oauth_base_dir / f"openai_codex_oauth_{i}.json"
+            try:
+                with open(local_path, "w") as f:
+                    json.dump(record, f, indent=2)
+                imported_paths.append(str(local_path.resolve()))
+            except Exception as e:
+                lib_logger.error(
+                    f"OpenAI Codex import: failed writing '{local_path.name}': {e}"
+                )
+
+        if imported_paths:
+            identifiers = []
+            for p in imported_paths:
+                try:
+                    with open(p, "r") as f:
+                        payload = json.load(f)
+                    meta = payload.get("_proxy_metadata", {})
+                    identifiers.append(
+                        meta.get("email") or meta.get("account_id") or Path(p).name
+                    )
+                except Exception:
+                    identifiers.append(Path(p).name)
+
+            lib_logger.info(
+                "OpenAI Codex first-run import complete: "
+                f"{len(imported_paths)} credential(s) imported ({', '.join(str(x) for x in identifiers)})"
+            )
+
+        return imported_paths
+
+    def _import_openai_codex_explicit_paths(self, source_paths: List[Path]) -> List[str]:
+        """
+        Import OpenAI Codex credentials from explicit OPENAI_CODEX_OAUTH_* paths.
+
+        Supports:
+        - Raw Codex CLI files (`~/.codex/auth.json`, `~/.codex-accounts.json`)
+        - Already-normalized proxy credential JSON files
+
+        Returns local normalized/copied paths under oauth_creds/.
+        """
+        if not source_paths:
+            return []
+
+        normalized_records: List[Dict[str, Any]] = []
+        passthrough_paths: List[Path] = []
+
+        for source_path in sorted(source_paths):
+            try:
+                with open(source_path, "r") as f:
+                    payload = json.load(f)
+            except Exception as e:
+                lib_logger.warning(
+                    f"OpenAI Codex explicit import: failed to parse '{source_path}': {e}. Falling back to direct copy."
+                )
+                passthrough_paths.append(source_path)
+                continue
+
+            # Raw ~/.codex/auth.json shape
+            if isinstance(payload, dict) and isinstance(payload.get("tokens"), dict):
+                record = self._normalize_openai_codex_auth_json_record(payload)
+                if record:
+                    normalized_records.append(record)
+                    continue
+
+            # Raw ~/.codex-accounts.json shape (object or root list)
+            accounts: List[Any] = []
+            if isinstance(payload, dict) and isinstance(payload.get("accounts"), list):
+                accounts = payload.get("accounts")
+            elif isinstance(payload, list):
+                accounts = payload
+
+            if accounts:
+                converted = 0
+                for idx, account in enumerate(accounts):
+                    if not isinstance(account, dict):
+                        lib_logger.warning(
+                            f"OpenAI Codex explicit import: skipping malformed account entry #{idx + 1} from '{source_path.name}'"
+                        )
+                        continue
+
+                    record = self._normalize_openai_codex_accounts_record(account)
+                    if record:
+                        normalized_records.append(record)
+                        converted += 1
+
+                if converted > 0:
+                    continue
+
+            # Already-normalized proxy format
+            if (
+                isinstance(payload, dict)
+                and isinstance(payload.get("access_token"), str)
+                and isinstance(payload.get("refresh_token"), str)
+            ):
+                passthrough_paths.append(source_path)
+                continue
+
+            # Unknown shape: preserve existing behavior (copy as-is)
+            passthrough_paths.append(source_path)
+
+        # Deduplicate normalized records by account_id/email
+        unique_records: List[Dict[str, Any]] = []
+        seen_account_ids: Set[str] = set()
+        seen_emails: Set[str] = set()
+
+        for record in normalized_records:
+            metadata = record.get("_proxy_metadata", {})
+            account_id = metadata.get("account_id")
+            email = metadata.get("email")
+
+            if isinstance(account_id, str) and account_id:
+                if account_id in seen_account_ids:
+                    continue
+                seen_account_ids.add(account_id)
+
+            if isinstance(email, str) and email:
+                if email in seen_emails:
+                    continue
+                seen_emails.add(email)
+
+            unique_records.append(record)
+
+        imported_paths: List[str] = []
+        next_index = 1
+
+        # Write normalized records first
+        for record in unique_records:
+            local_path = self.oauth_base_dir / f"openai_codex_oauth_{next_index}.json"
+            try:
+                with open(local_path, "w") as f:
+                    json.dump(record, f, indent=2)
+                imported_paths.append(str(local_path.resolve()))
+                next_index += 1
+            except Exception as e:
+                lib_logger.error(
+                    f"OpenAI Codex explicit import: failed writing '{local_path.name}': {e}"
+                )
+
+        # Copy passthrough files after normalized ones
+        for source_path in passthrough_paths:
+            local_path = self.oauth_base_dir / f"openai_codex_oauth_{next_index}.json"
+            try:
+                shutil.copy(source_path, local_path)
+                imported_paths.append(str(local_path.resolve()))
+                next_index += 1
+            except Exception as e:
+                lib_logger.error(
+                    f"OpenAI Codex explicit import: failed to copy '{source_path}' -> '{local_path}': {e}"
+                )
+
+        if imported_paths:
+            lib_logger.info(
+                "OpenAI Codex explicit-path import complete: "
+                f"{len(imported_paths)} credential(s) prepared"
+            )
+
+        return imported_paths
+
     def discover_and_prepare(self) -> Dict[str, List[str]]:
         lib_logger.info("Starting automated OAuth credential discovery...")
         final_config = {}
@@ -165,7 +599,7 @@ class CredentialManager:
                 ]
                 continue
 
-            # If no local credentials exist, proceed with a one-time discovery and copy.
+            # If no local credentials exist, proceed with one-time import/copy.
             discovered_paths = set()
 
             # 1. Add paths from environment variables first, as they are overrides
@@ -174,8 +608,30 @@ class CredentialManager:
                 if path.exists():
                     discovered_paths.add(path)
 
-            # 2. If no overrides are provided via .env, scan the default directory
-            # [MODIFIED] This logic is now disabled to prefer local-first credential management.
+            # 2. Provider-specific first-run import for OpenAI Codex
+            # Trigger only when:
+            # - provider == openai_codex
+            # - no local openai_codex_oauth_*.json already exist (checked above)
+            # - no env-based OPENAI_CODEX credentials were selected (provider not in final_config)
+            # - no explicit OPENAI_CODEX_OAUTH_* file paths were provided
+            if provider == "openai_codex" and not discovered_paths:
+                imported = self._import_openai_codex_cli_credentials()
+                if imported:
+                    final_config[provider] = imported
+                    continue
+
+            # 3. Provider-specific explicit-path import handling for OpenAI Codex
+            # This normalizes raw ~/.codex/auth.json / ~/.codex-accounts.json when
+            # supplied via OPENAI_CODEX_OAUTH_* env vars.
+            if provider == "openai_codex" and discovered_paths:
+                imported = self._import_openai_codex_explicit_paths(
+                    sorted(list(discovered_paths))
+                )
+                if imported:
+                    final_config[provider] = imported
+                    continue
+
+            # 4. Default directory scan remains disabled (local-first policy)
             # if not discovered_paths and default_dir.exists():
             #     for json_file in default_dir.glob('*.json'):
             #         discovered_paths.add(json_file)

--- a/src/rotator_library/credential_tool.py
+++ b/src/rotator_library/credential_tool.py
@@ -66,6 +66,7 @@ OAUTH_FRIENDLY_NAMES = {
     "qwen_code": "Qwen Code",
     "iflow": "iFlow",
     "antigravity": "Antigravity",
+    "openai_codex": "OpenAI Codex",
 }
 
 
@@ -269,7 +270,13 @@ def _get_oauth_credentials_summary() -> dict:
         Example: {"gemini_cli": [{"email": "user@example.com", "tier": "free-tier", ...}, ...]}
     """
     provider_factory, _ = _ensure_providers_loaded()
-    oauth_providers = ["gemini_cli", "qwen_code", "iflow", "antigravity"]
+    oauth_providers = [
+        "gemini_cli",
+        "qwen_code",
+        "iflow",
+        "antigravity",
+        "openai_codex",
+    ]
     oauth_summary = {}
 
     for provider_name in oauth_providers:
@@ -1214,6 +1221,7 @@ async def setup_api_key():
         "antigravity",  # OAuth-only
         "qwen_code",  # OAuth is primary, don't advertise API key
         "iflow",  # OAuth is primary
+        "openai_codex",  # OAuth-only (ChatGPT OAuth)
     }
 
     # Base classes to exclude
@@ -1732,6 +1740,7 @@ async def setup_new_credential(provider_name: str):
             "qwen_code": "Qwen Code (OAuth - also supports API keys)",
             "iflow": "iFlow",
             "antigravity": "Antigravity (OAuth)",
+            "openai_codex": "OpenAI Codex (OAuth)",
         }
         display_name = oauth_friendly_names.get(
             provider_name, provider_name.replace("_", " ").title()
@@ -2202,6 +2211,96 @@ async def export_antigravity_to_env():
         )
 
 
+async def export_openai_codex_to_env():
+    """
+    Export an OpenAI Codex credential JSON file to .env format.
+    Uses the auth class's build_env_lines() and list_credentials() methods.
+    """
+    clear_screen("Export OpenAI Codex Credential")
+
+    provider_factory, _ = _ensure_providers_loaded()
+    auth_class = provider_factory.get_provider_auth_class("openai_codex")
+    auth_instance = auth_class()
+
+    credentials = auth_instance.list_credentials(_get_oauth_base_dir())
+
+    if not credentials:
+        console.print(
+            Panel(
+                "No OpenAI Codex credentials found. Please add one first using 'Add OAuth Credential'.",
+                style="bold red",
+                title="No Credentials",
+            )
+        )
+        return
+
+    cred_text = Text()
+    for i, cred_info in enumerate(credentials):
+        cred_text.append(
+            f"  {i + 1}. {Path(cred_info['file_path']).name} ({cred_info['email']})\n"
+        )
+
+    console.print(
+        Panel(
+            cred_text,
+            title="Available OpenAI Codex Credentials",
+            style="bold blue",
+        )
+    )
+
+    choice = Prompt.ask(
+        Text.from_markup(
+            "[bold]Please select a credential to export or type [red]'b'[/red] to go back[/bold]"
+        ),
+        choices=[str(i + 1) for i in range(len(credentials))] + ["b"],
+        show_choices=False,
+    )
+
+    if choice.lower() == "b":
+        return
+
+    try:
+        choice_index = int(choice) - 1
+        if 0 <= choice_index < len(credentials):
+            cred_info = credentials[choice_index]
+
+            env_path = auth_instance.export_credential_to_env(
+                cred_info["file_path"], _get_oauth_base_dir()
+            )
+
+            if env_path:
+                numbered_prefix = f"OPENAI_CODEX_{cred_info['number']}"
+                success_text = Text.from_markup(
+                    f"Successfully exported credential to [bold yellow]'{Path(env_path).name}'[/bold yellow]\n\n"
+                    f"[bold]Environment variable prefix:[/bold] [cyan]{numbered_prefix}_*[/cyan]\n\n"
+                    f"[bold]To use this credential:[/bold]\n"
+                    f"1. Copy the contents to your main .env file, OR\n"
+                    f"2. Source it: [bold cyan]source {Path(env_path).name}[/bold cyan] (Linux/Mac)\n\n"
+                    f"[bold]To combine multiple credentials:[/bold]\n"
+                    f"Copy lines from multiple .env files into one file.\n"
+                    f"Each credential uses a unique number ({numbered_prefix}_*)."
+                )
+                console.print(Panel(success_text, style="bold green", title="Success"))
+            else:
+                console.print(
+                    Panel(
+                        "Failed to export credential", style="bold red", title="Error"
+                    )
+                )
+        else:
+            console.print("[bold red]Invalid choice. Please try again.[/bold red]")
+    except ValueError:
+        console.print(
+            "[bold red]Invalid input. Please enter a number or 'b'.[/bold red]"
+        )
+    except Exception as e:
+        console.print(
+            Panel(
+                f"An error occurred during export: {e}", style="bold red", title="Error"
+            )
+        )
+
+
 async def export_all_provider_credentials(provider_name: str):
     """
     Export all credentials for a specific provider to individual .env files.
@@ -2366,7 +2465,13 @@ async def combine_all_credentials():
     clear_screen("Combine All Credentials")
 
     # List of providers that support OAuth credentials
-    oauth_providers = ["gemini_cli", "qwen_code", "iflow", "antigravity"]
+    oauth_providers = [
+        "gemini_cli",
+        "qwen_code",
+        "iflow",
+        "antigravity",
+        "openai_codex",
+    ]
 
     provider_factory, _ = _ensure_providers_loaded()
 
@@ -2471,19 +2576,22 @@ async def export_credentials_submenu():
                     "2. Export Qwen Code credential\n"
                     "3. Export iFlow credential\n"
                     "4. Export Antigravity credential\n"
+                    "5. Export OpenAI Codex credential\n"
                     "\n"
                     "[bold]Bulk Exports (per provider):[/bold]\n"
-                    "5. Export ALL Gemini CLI credentials\n"
-                    "6. Export ALL Qwen Code credentials\n"
-                    "7. Export ALL iFlow credentials\n"
-                    "8. Export ALL Antigravity credentials\n"
+                    "6. Export ALL Gemini CLI credentials\n"
+                    "7. Export ALL Qwen Code credentials\n"
+                    "8. Export ALL iFlow credentials\n"
+                    "9. Export ALL Antigravity credentials\n"
+                    "10. Export ALL OpenAI Codex credentials\n"
                     "\n"
                     "[bold]Combine Credentials:[/bold]\n"
-                    "9. Combine all Gemini CLI into one file\n"
-                    "10. Combine all Qwen Code into one file\n"
-                    "11. Combine all iFlow into one file\n"
-                    "12. Combine all Antigravity into one file\n"
-                    "13. Combine ALL providers into one file"
+                    "11. Combine all Gemini CLI into one file\n"
+                    "12. Combine all Qwen Code into one file\n"
+                    "13. Combine all iFlow into one file\n"
+                    "14. Combine all Antigravity into one file\n"
+                    "15. Combine all OpenAI Codex into one file\n"
+                    "16. Combine ALL providers into one file"
                 ),
                 title="Choose export option",
                 style="bold blue",
@@ -2508,6 +2616,9 @@ async def export_credentials_submenu():
                 "11",
                 "12",
                 "13",
+                "14",
+                "15",
+                "16",
                 "b",
             ],
             show_choices=False,
@@ -2533,42 +2644,54 @@ async def export_credentials_submenu():
             await export_antigravity_to_env()
             console.print("\n[dim]Press Enter to return to export menu...[/dim]")
             input()
-        # Bulk exports (all credentials for a provider)
         elif export_choice == "5":
+            await export_openai_codex_to_env()
+            console.print("\n[dim]Press Enter to return to export menu...[/dim]")
+            input()
+        # Bulk exports (all credentials for a provider)
+        elif export_choice == "6":
             await export_all_provider_credentials("gemini_cli")
             console.print("\n[dim]Press Enter to return to export menu...[/dim]")
             input()
-        elif export_choice == "6":
+        elif export_choice == "7":
             await export_all_provider_credentials("qwen_code")
             console.print("\n[dim]Press Enter to return to export menu...[/dim]")
             input()
-        elif export_choice == "7":
+        elif export_choice == "8":
             await export_all_provider_credentials("iflow")
             console.print("\n[dim]Press Enter to return to export menu...[/dim]")
             input()
-        elif export_choice == "8":
+        elif export_choice == "9":
             await export_all_provider_credentials("antigravity")
             console.print("\n[dim]Press Enter to return to export menu...[/dim]")
             input()
+        elif export_choice == "10":
+            await export_all_provider_credentials("openai_codex")
+            console.print("\n[dim]Press Enter to return to export menu...[/dim]")
+            input()
         # Combine per provider
-        elif export_choice == "9":
+        elif export_choice == "11":
             await combine_provider_credentials("gemini_cli")
             console.print("\n[dim]Press Enter to return to export menu...[/dim]")
             input()
-        elif export_choice == "10":
+        elif export_choice == "12":
             await combine_provider_credentials("qwen_code")
             console.print("\n[dim]Press Enter to return to export menu...[/dim]")
             input()
-        elif export_choice == "11":
+        elif export_choice == "13":
             await combine_provider_credentials("iflow")
             console.print("\n[dim]Press Enter to return to export menu...[/dim]")
             input()
-        elif export_choice == "12":
+        elif export_choice == "14":
             await combine_provider_credentials("antigravity")
             console.print("\n[dim]Press Enter to return to export menu...[/dim]")
             input()
+        elif export_choice == "15":
+            await combine_provider_credentials("openai_codex")
+            console.print("\n[dim]Press Enter to return to export menu...[/dim]")
+            input()
         # Combine all providers
-        elif export_choice == "13":
+        elif export_choice == "16":
             await combine_all_credentials()
             console.print("\n[dim]Press Enter to return to export menu...[/dim]")
             input()

--- a/src/rotator_library/provider_factory.py
+++ b/src/rotator_library/provider_factory.py
@@ -7,12 +7,14 @@ from .providers.gemini_auth_base import GeminiAuthBase
 from .providers.qwen_auth_base import QwenAuthBase
 from .providers.iflow_auth_base import IFlowAuthBase
 from .providers.antigravity_auth_base import AntigravityAuthBase
+from .providers.openai_codex_auth_base import OpenAICodexAuthBase
 
 PROVIDER_MAP = {
     "gemini_cli": GeminiAuthBase,
     "qwen_code": QwenAuthBase,
     "iflow": IFlowAuthBase,
     "antigravity": AntigravityAuthBase,
+    "openai_codex": OpenAICodexAuthBase,
 }
 
 def get_provider_auth_class(provider_name: str):

--- a/src/rotator_library/providers/openai_codex_auth_base.py
+++ b/src/rotator_library/providers/openai_codex_auth_base.py
@@ -1,0 +1,1460 @@
+# SPDX-License-Identifier: LGPL-3.0-only
+# Copyright (c) 2026 Mirrowel
+
+# src/rotator_library/providers/openai_codex_auth_base.py
+
+import asyncio
+import base64
+import copy
+import hashlib
+import json
+import logging
+import os
+import re
+import secrets
+import time
+import webbrowser
+from dataclasses import dataclass, field
+from glob import glob
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+from urllib.parse import urlencode
+
+import httpx
+from aiohttp import web
+from rich.console import Console
+from rich.markup import escape as rich_escape
+from rich.panel import Panel
+from rich.text import Text
+
+from ..error_handler import CredentialNeedsReauthError
+from ..utils.headless_detection import is_headless_environment
+from ..utils.reauth_coordinator import get_reauth_coordinator
+from ..utils.resilient_io import safe_write_json
+
+lib_logger = logging.getLogger("rotator_library")
+
+# OAuth constants
+CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+SCOPE = "openid profile email offline_access"
+AUTHORIZATION_ENDPOINT = "https://auth.openai.com/oauth/authorize"
+TOKEN_ENDPOINT = "https://auth.openai.com/oauth/token"
+CALLBACK_PATH = "/oauth2callback"
+CALLBACK_PORT = 1455
+CALLBACK_ENV_VAR = "OPENAI_CODEX_OAUTH_PORT"
+
+# API constants
+DEFAULT_API_BASE = "https://chatgpt.com/backend-api"
+RESPONSES_ENDPOINT_PATH = "/codex/responses"
+
+# JWT claims
+AUTH_CLAIM = "https://api.openai.com/auth"
+ACCOUNT_ID_CLAIM = "https://api.openai.com/auth.chatgpt_account_id"
+
+# Refresh when token is close to expiry
+REFRESH_EXPIRY_BUFFER_SECONDS = 5 * 60  # 5 minutes
+
+console = Console()
+
+
+@dataclass
+class OpenAICodexCredentialSetupResult:
+    """Standardized result structure for OpenAI Codex credential setup operations."""
+
+    success: bool
+    file_path: Optional[str] = None
+    email: Optional[str] = None
+    is_update: bool = False
+    error: Optional[str] = None
+    credentials: Optional[Dict[str, Any]] = field(default=None, repr=False)
+
+
+class OAuthCallbackServer:
+    """Minimal HTTP server for handling OpenAI Codex OAuth callbacks."""
+
+    SUCCESS_HTML = """<!doctype html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\" />
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+  <title>Authentication successful</title>
+</head>
+<body>
+  <p>Authentication successful. Return to your terminal to continue.</p>
+</body>
+</html>"""
+
+    def __init__(self, port: int = CALLBACK_PORT):
+        self.port = port
+        self.app = web.Application()
+        self.runner: Optional[web.AppRunner] = None
+        self.site: Optional[web.TCPSite] = None
+        self.result_future: Optional[asyncio.Future] = None
+        self.expected_state: Optional[str] = None
+
+    async def start(self, expected_state: str):
+        """Start callback server on localhost:<port>."""
+        self.expected_state = expected_state
+        self.result_future = asyncio.Future()
+
+        self.app.router.add_get(CALLBACK_PATH, self._handle_callback)
+
+        self.runner = web.AppRunner(self.app)
+        await self.runner.setup()
+        self.site = web.TCPSite(self.runner, "localhost", self.port)
+        await self.site.start()
+
+        lib_logger.debug(
+            f"OpenAI Codex OAuth callback server started on localhost:{self.port}{CALLBACK_PATH}"
+        )
+
+    async def stop(self):
+        """Stop callback server."""
+        if self.site:
+            await self.site.stop()
+        if self.runner:
+            await self.runner.cleanup()
+        lib_logger.debug("OpenAI Codex OAuth callback server stopped")
+
+    async def _handle_callback(self, request: web.Request) -> web.Response:
+        query = request.query
+
+        if "error" in query:
+            error = query.get("error", "unknown_error")
+            error_desc = query.get("error_description", "")
+            if not self.result_future.done():
+                self.result_future.set_exception(
+                    ValueError(f"OAuth error: {error} ({error_desc})")
+                )
+            return web.Response(status=400, text=f"OAuth error: {error}")
+
+        code = query.get("code")
+        state = query.get("state", "")
+
+        if not code:
+            if not self.result_future.done():
+                self.result_future.set_exception(
+                    ValueError("Missing authorization code")
+                )
+            return web.Response(status=400, text="Missing authorization code")
+
+        if state != self.expected_state:
+            if not self.result_future.done():
+                self.result_future.set_exception(ValueError("State parameter mismatch"))
+            return web.Response(status=400, text="State mismatch")
+
+        if not self.result_future.done():
+            self.result_future.set_result(code)
+
+        return web.Response(
+            status=200,
+            text=self.SUCCESS_HTML,
+            content_type="text/html",
+        )
+
+    async def wait_for_callback(self, timeout: float = 300.0) -> str:
+        """Wait for OAuth callback and return auth code."""
+        try:
+            code = await asyncio.wait_for(self.result_future, timeout=timeout)
+            return code
+        except asyncio.TimeoutError:
+            raise TimeoutError("Timeout waiting for OAuth callback")
+
+
+def get_callback_port() -> int:
+    """Get OAuth callback port from env or fallback default."""
+    env_value = os.getenv(CALLBACK_ENV_VAR)
+    if env_value:
+        try:
+            return int(env_value)
+        except ValueError:
+            lib_logger.warning(
+                f"Invalid {CALLBACK_ENV_VAR} value: {env_value}, using default {CALLBACK_PORT}"
+            )
+    return CALLBACK_PORT
+
+
+class OpenAICodexAuthBase:
+    """
+    OpenAI Codex OAuth authentication base class.
+
+    Supports:
+    - Interactive OAuth Authorization Code + PKCE
+    - Token refresh with retry/backoff
+    - File + env credential loading (`env://openai_codex/N`)
+    - Queue-based refresh and re-auth workflows
+    - Credential management APIs for credential_tool
+    """
+
+    CALLBACK_PORT = CALLBACK_PORT
+    CALLBACK_ENV_VAR = CALLBACK_ENV_VAR
+
+    def __init__(self):
+        self._credentials_cache: Dict[str, Dict[str, Any]] = {}
+        self._refresh_locks: Dict[str, asyncio.Lock] = {}
+        self._locks_lock = asyncio.Lock()
+
+        # Backoff tracking
+        self._refresh_failures: Dict[str, int] = {}
+        self._next_refresh_after: Dict[str, float] = {}
+
+        # Queue system (normal refresh + interactive re-auth)
+        self._refresh_queue: asyncio.Queue = asyncio.Queue()
+        self._queue_processor_task: Optional[asyncio.Task] = None
+
+        self._reauth_queue: asyncio.Queue = asyncio.Queue()
+        self._reauth_processor_task: Optional[asyncio.Task] = None
+
+        self._queued_credentials: set = set()
+        self._unavailable_credentials: Dict[str, float] = {}
+        self._unavailable_ttl_seconds: int = 360
+        self._queue_tracking_lock = asyncio.Lock()
+
+        self._queue_retry_count: Dict[str, int] = {}
+
+        # Queue configuration
+        self._refresh_timeout_seconds: int = 20
+        self._refresh_interval_seconds: int = 20
+        self._refresh_max_retries: int = 3
+        self._reauth_timeout_seconds: int = 300
+
+    # =========================================================================
+    # JWT + metadata helpers
+    # =========================================================================
+
+    @staticmethod
+    def _decode_jwt_unverified(token: str) -> Optional[Dict[str, Any]]:
+        """Decode JWT payload without signature verification."""
+        if not token or not isinstance(token, str):
+            return None
+
+        parts = token.split(".")
+        if len(parts) < 2:
+            return None
+
+        payload_segment = parts[1]
+        padding = "=" * (-len(payload_segment) % 4)
+
+        try:
+            payload_bytes = base64.urlsafe_b64decode(payload_segment + padding)
+            payload = json.loads(payload_bytes.decode("utf-8"))
+            return payload if isinstance(payload, dict) else None
+        except Exception:
+            return None
+
+    @staticmethod
+    def _extract_account_id_from_payload(payload: Optional[Dict[str, Any]]) -> Optional[str]:
+        """Extract account ID from JWT claims."""
+        if not payload:
+            return None
+
+        # 1) Direct dotted claim format (requested by plan)
+        direct = payload.get(ACCOUNT_ID_CLAIM)
+        if isinstance(direct, str) and direct.strip():
+            return direct.strip()
+
+        # 2) Nested object claim format observed in real tokens
+        auth_claim = payload.get(AUTH_CLAIM)
+        if isinstance(auth_claim, dict):
+            nested = auth_claim.get("chatgpt_account_id")
+            if isinstance(nested, str) and nested.strip():
+                return nested.strip()
+
+        # 3) Fallback organizations[0].id if present
+        orgs = payload.get("organizations")
+        if isinstance(orgs, list) and orgs:
+            first = orgs[0]
+            if isinstance(first, dict):
+                org_id = first.get("id")
+                if isinstance(org_id, str) and org_id.strip():
+                    return org_id.strip()
+
+        return None
+
+    @staticmethod
+    def _extract_email_from_payload(payload: Optional[Dict[str, Any]]) -> Optional[str]:
+        """Extract email from JWT payload using fallback chain: email -> sub."""
+        if not payload:
+            return None
+
+        email = payload.get("email")
+        if isinstance(email, str) and email.strip():
+            return email.strip()
+
+        sub = payload.get("sub")
+        if isinstance(sub, str) and sub.strip():
+            return sub.strip()
+
+        return None
+
+    @staticmethod
+    def _extract_expiry_ms_from_payload(payload: Optional[Dict[str, Any]]) -> Optional[int]:
+        """Extract JWT exp claim and convert to milliseconds."""
+        if not payload:
+            return None
+
+        exp = payload.get("exp")
+        if isinstance(exp, (int, float)):
+            return int(float(exp) * 1000)
+
+        return None
+
+    def _populate_metadata_from_tokens(self, creds: Dict[str, Any]) -> None:
+        """Populate _proxy_metadata (email/account_id) from access_token or id_token."""
+        metadata = creds.setdefault("_proxy_metadata", {})
+
+        access_payload = self._decode_jwt_unverified(creds.get("access_token", ""))
+        id_payload = self._decode_jwt_unverified(creds.get("id_token", ""))
+
+        account_id = self._extract_account_id_from_payload(
+            access_payload
+        ) or self._extract_account_id_from_payload(id_payload)
+        email = self._extract_email_from_payload(access_payload) or self._extract_email_from_payload(
+            id_payload
+        )
+
+        if account_id:
+            metadata["account_id"] = account_id
+
+        if email:
+            metadata["email"] = email
+
+        # Keep top-level expiry_date synchronized from token exp as fallback
+        if not creds.get("expiry_date"):
+            expiry_ms = self._extract_expiry_ms_from_payload(access_payload) or self._extract_expiry_ms_from_payload(
+                id_payload
+            )
+            if expiry_ms:
+                creds["expiry_date"] = expiry_ms
+
+        metadata["last_check_timestamp"] = time.time()
+
+    def _ensure_proxy_metadata(self, creds: Dict[str, Any]) -> Dict[str, Any]:
+        """Ensure credentials include normalized _proxy_metadata fields."""
+        metadata = creds.setdefault("_proxy_metadata", {})
+        metadata.setdefault("loaded_from_env", False)
+        metadata.setdefault("env_credential_index", None)
+
+        self._populate_metadata_from_tokens(creds)
+
+        # Keep top-level token_uri stable for schema consistency
+        creds.setdefault("token_uri", TOKEN_ENDPOINT)
+
+        return creds
+
+    # =========================================================================
+    # Env + file credential loading
+    # =========================================================================
+
+    def _parse_env_credential_path(self, path: str) -> Optional[str]:
+        """
+        Parse a virtual env:// path and return the credential index.
+
+        Supported formats:
+        - env://openai_codex/0  (legacy single)
+        - env://openai_codex/1  (numbered)
+        """
+        if not path.startswith("env://"):
+            return None
+
+        raw = path[6:]
+        parts = raw.split("/")
+        if not parts:
+            return None
+
+        provider = parts[0].strip().lower()
+        if provider != "openai_codex":
+            return None
+
+        if len(parts) >= 2 and parts[1].strip():
+            return parts[1].strip()
+
+        return "0"
+
+    def _load_from_env(
+        self, credential_index: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Load OpenAI Codex OAuth credentials from environment variables.
+
+        Legacy single credential:
+        - OPENAI_CODEX_ACCESS_TOKEN
+        - OPENAI_CODEX_REFRESH_TOKEN
+        - OPENAI_CODEX_EXPIRY_DATE (optional)
+        - OPENAI_CODEX_ID_TOKEN (optional)
+        - OPENAI_CODEX_ACCOUNT_ID (optional)
+        - OPENAI_CODEX_EMAIL (optional)
+
+        Numbered credentials (N):
+        - OPENAI_CODEX_N_ACCESS_TOKEN
+        - OPENAI_CODEX_N_REFRESH_TOKEN
+        - OPENAI_CODEX_N_EXPIRY_DATE (optional)
+        - OPENAI_CODEX_N_ID_TOKEN (optional)
+        - OPENAI_CODEX_N_ACCOUNT_ID (optional)
+        - OPENAI_CODEX_N_EMAIL (optional)
+        """
+        if credential_index and credential_index != "0":
+            prefix = f"OPENAI_CODEX_{credential_index}"
+            default_email = f"env-user-{credential_index}"
+            env_index = credential_index
+        else:
+            prefix = "OPENAI_CODEX"
+            default_email = "env-user"
+            env_index = "0"
+
+        access_token = os.getenv(f"{prefix}_ACCESS_TOKEN")
+        refresh_token = os.getenv(f"{prefix}_REFRESH_TOKEN")
+
+        if not (access_token and refresh_token):
+            return None
+
+        expiry_raw = os.getenv(f"{prefix}_EXPIRY_DATE", "")
+        expiry_date: Optional[int] = None
+        if expiry_raw:
+            try:
+                expiry_date = int(float(expiry_raw))
+            except ValueError:
+                lib_logger.warning(f"Invalid {prefix}_EXPIRY_DATE: {expiry_raw}")
+
+        id_token = os.getenv(f"{prefix}_ID_TOKEN")
+        account_id = os.getenv(f"{prefix}_ACCOUNT_ID")
+        email = os.getenv(f"{prefix}_EMAIL")
+
+        creds: Dict[str, Any] = {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "id_token": id_token,
+            "token_uri": TOKEN_ENDPOINT,
+            "expiry_date": expiry_date or 0,
+            "_proxy_metadata": {
+                "email": email or default_email,
+                "account_id": account_id,
+                "last_check_timestamp": time.time(),
+                "loaded_from_env": True,
+                "env_credential_index": env_index,
+            },
+        }
+
+        # Fill missing metadata/expiry from JWT claims
+        self._populate_metadata_from_tokens(creds)
+
+        # If expiry still missing, set conservative short expiry to trigger refresh soon
+        if not creds.get("expiry_date"):
+            creds["expiry_date"] = int((time.time() + 300) * 1000)
+
+        return creds
+
+    async def _read_creds_from_file(self, path: str) -> Dict[str, Any]:
+        """Read credentials from disk and update cache."""
+        try:
+            with open(path, "r") as f:
+                creds = json.load(f)
+
+            if not isinstance(creds, dict):
+                raise ValueError("Credential file root must be a JSON object")
+
+            creds = self._ensure_proxy_metadata(creds)
+            self._credentials_cache[path] = creds
+            return creds
+
+        except FileNotFoundError:
+            raise IOError(f"OpenAI Codex credential file not found at '{path}'")
+        except Exception as e:
+            raise IOError(
+                f"Failed to load OpenAI Codex credentials from '{path}': {e}"
+            )
+
+    async def _load_credentials(self, path: str) -> Dict[str, Any]:
+        """Load credentials from cache, env, or file."""
+        if path in self._credentials_cache:
+            return self._credentials_cache[path]
+
+        async with await self._get_lock(path):
+            if path in self._credentials_cache:
+                return self._credentials_cache[path]
+
+            credential_index = self._parse_env_credential_path(path)
+            if credential_index is not None:
+                env_creds = self._load_from_env(credential_index)
+                if env_creds:
+                    self._credentials_cache[path] = env_creds
+                    lib_logger.info(
+                        f"Using OpenAI Codex env credential index {credential_index}"
+                    )
+                    return env_creds
+                raise IOError(
+                    f"Environment variables for OpenAI Codex credential index {credential_index} not found"
+                )
+
+            # File-based path, with legacy env fallback for backwards compatibility
+            try:
+                return await self._read_creds_from_file(path)
+            except IOError:
+                env_creds = self._load_from_env("0")
+                if env_creds:
+                    self._credentials_cache[path] = env_creds
+                    lib_logger.info(
+                        f"File '{path}' not found; using legacy OPENAI_CODEX_* environment credentials"
+                    )
+                    return env_creds
+                raise
+
+    async def _save_credentials(self, path: str, creds: Dict[str, Any]) -> bool:
+        """
+        Save credentials to disk, then update cache.
+
+        Critical semantics:
+        - For rotating refresh tokens, disk write must succeed before cache update.
+        - Env-backed creds skip disk writes and update in-memory cache only.
+        """
+        creds = self._ensure_proxy_metadata(copy.deepcopy(creds))
+
+        loaded_from_env = creds.get("_proxy_metadata", {}).get("loaded_from_env", False)
+        if loaded_from_env or self._parse_env_credential_path(path) is not None:
+            self._credentials_cache[path] = creds
+            lib_logger.debug(
+                f"OpenAI Codex credential '{path}' is env-backed; skipping disk write"
+            )
+            return True
+
+        if not safe_write_json(
+            path,
+            creds,
+            lib_logger,
+            secure_permissions=True,
+            buffer_on_failure=False,
+        ):
+            lib_logger.error(
+                f"Failed to persist OpenAI Codex credentials for '{Path(path).name}'. Cache not updated."
+            )
+            return False
+
+        self._credentials_cache[path] = creds
+        return True
+
+    # =========================================================================
+    # Expiry / refresh helpers
+    # =========================================================================
+
+    def _is_token_expired(self, creds: Dict[str, Any]) -> bool:
+        """Proactive expiry check using refresh buffer."""
+        expiry_timestamp = float(creds.get("expiry_date", 0)) / 1000
+        return expiry_timestamp < time.time() + REFRESH_EXPIRY_BUFFER_SECONDS
+
+    def _is_token_truly_expired(self, creds: Dict[str, Any]) -> bool:
+        """Strict expiry check without proactive buffer."""
+        expiry_timestamp = float(creds.get("expiry_date", 0)) / 1000
+        return expiry_timestamp < time.time()
+
+    async def _exchange_code_for_tokens(
+        self, code: str, code_verifier: str, redirect_uri: str
+    ) -> Dict[str, Any]:
+        """Exchange OAuth authorization code for tokens."""
+        payload = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": CLIENT_ID,
+            "redirect_uri": redirect_uri,
+            "code_verifier": code_verifier,
+        }
+
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+            "User-Agent": "LLM-API-Key-Proxy/OpenAICodex",
+        }
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(TOKEN_ENDPOINT, headers=headers, data=payload)
+            response.raise_for_status()
+            token_data = response.json()
+
+        access_token = token_data.get("access_token")
+        refresh_token = token_data.get("refresh_token")
+        expires_in = token_data.get("expires_in")
+
+        if not access_token or not refresh_token or not isinstance(expires_in, (int, float)):
+            raise ValueError("Token exchange response missing required fields")
+
+        return token_data
+
+    async def _refresh_token(self, path: str, force: bool = False) -> Dict[str, Any]:
+        """Refresh access token using refresh_token with retry/backoff."""
+        async with await self._get_lock(path):
+            cached_creds = self._credentials_cache.get(path)
+            if not force and cached_creds and not self._is_token_expired(cached_creds):
+                return cached_creds
+
+            # Always load freshest source before refresh attempt
+            is_env = self._parse_env_credential_path(path) is not None
+            if is_env:
+                source_creds = copy.deepcopy(await self._load_credentials(path))
+            else:
+                await self._read_creds_from_file(path)
+                source_creds = copy.deepcopy(self._credentials_cache[path])
+
+            refresh_token = source_creds.get("refresh_token")
+            if not refresh_token:
+                raise ValueError("No refresh_token found in OpenAI Codex credentials")
+
+            headers = {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json",
+                "User-Agent": "LLM-API-Key-Proxy/OpenAICodex",
+            }
+
+            max_retries = 3
+            token_data = None
+            last_error: Optional[Exception] = None
+
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                for attempt in range(max_retries):
+                    try:
+                        response = await client.post(
+                            TOKEN_ENDPOINT,
+                            headers=headers,
+                            data={
+                                "grant_type": "refresh_token",
+                                "refresh_token": refresh_token,
+                                "client_id": CLIENT_ID,
+                            },
+                        )
+                        response.raise_for_status()
+                        token_data = response.json()
+                        break
+
+                    except httpx.HTTPStatusError as e:
+                        last_error = e
+                        status_code = e.response.status_code
+
+                        error_type = ""
+                        error_desc = ""
+                        try:
+                            payload = e.response.json()
+                            error_type = payload.get("error", "")
+                            error_desc = payload.get("error_description", "") or payload.get(
+                                "message", ""
+                            )
+                        except Exception:
+                            error_desc = e.response.text
+
+                        # invalid_grant and authorization failures should trigger re-auth queue
+                        if status_code == 400:
+                            if (
+                                error_type == "invalid_grant"
+                                or "invalid_grant" in error_desc.lower()
+                                or "invalid" in error_desc.lower()
+                            ):
+                                asyncio.create_task(
+                                    self._queue_refresh(path, force=True, needs_reauth=True)
+                                )
+                                raise CredentialNeedsReauthError(
+                                    credential_path=path,
+                                    message=(
+                                        f"OpenAI Codex refresh token invalid for '{Path(path).name}'. Re-auth queued."
+                                    ),
+                                )
+                            raise
+
+                        if status_code in (401, 403):
+                            asyncio.create_task(
+                                self._queue_refresh(path, force=True, needs_reauth=True)
+                            )
+                            raise CredentialNeedsReauthError(
+                                credential_path=path,
+                                message=(
+                                    f"OpenAI Codex credential '{Path(path).name}' unauthorized (HTTP {status_code}). Re-auth queued."
+                                ),
+                            )
+
+                        if status_code == 429:
+                            retry_after = e.response.headers.get("Retry-After", "60")
+                            try:
+                                wait_seconds = max(1, int(float(retry_after)))
+                            except ValueError:
+                                wait_seconds = 60
+
+                            if attempt < max_retries - 1:
+                                await asyncio.sleep(wait_seconds)
+                                continue
+                            raise
+
+                        if 500 <= status_code < 600:
+                            if attempt < max_retries - 1:
+                                await asyncio.sleep(2**attempt)
+                                continue
+                            raise
+
+                        raise
+
+                    except (httpx.RequestError, httpx.TimeoutException) as e:
+                        last_error = e
+                        if attempt < max_retries - 1:
+                            await asyncio.sleep(2**attempt)
+                            continue
+                        raise
+
+            if token_data is None:
+                self._refresh_failures[path] = self._refresh_failures.get(path, 0) + 1
+                backoff_seconds = min(300, 30 * (2 ** self._refresh_failures[path]))
+                self._next_refresh_after[path] = time.time() + backoff_seconds
+                raise last_error or Exception("OpenAI Codex token refresh failed")
+
+            access_token = token_data.get("access_token")
+            if not access_token:
+                raise ValueError("Refresh response missing access_token")
+
+            expires_in = token_data.get("expires_in")
+            if not isinstance(expires_in, (int, float)):
+                raise ValueError("Refresh response missing expires_in")
+
+            # Build UPDATED credential object (do not mutate cached source in-place)
+            updated_creds = copy.deepcopy(source_creds)
+            updated_creds["access_token"] = access_token
+            updated_creds["refresh_token"] = token_data.get(
+                "refresh_token", updated_creds.get("refresh_token")
+            )
+
+            if token_data.get("id_token"):
+                updated_creds["id_token"] = token_data.get("id_token")
+
+            updated_creds["expiry_date"] = int((time.time() + float(expires_in)) * 1000)
+            updated_creds["token_uri"] = TOKEN_ENDPOINT
+
+            self._ensure_proxy_metadata(updated_creds)
+
+            if not updated_creds.get("access_token") or not updated_creds.get(
+                "refresh_token"
+            ):
+                raise ValueError("Refreshed credentials missing required token fields")
+
+            # Successful refresh clears backoff tracking
+            self._refresh_failures.pop(path, None)
+            self._next_refresh_after.pop(path, None)
+
+            # Persist before mutating shared cache state
+            if not await self._save_credentials(path, updated_creds):
+                raise IOError(
+                    f"Failed to persist refreshed OpenAI Codex credential '{Path(path).name}'"
+                )
+
+            return self._credentials_cache[path]
+
+    # =========================================================================
+    # Interactive OAuth flow
+    # =========================================================================
+
+    async def _perform_interactive_oauth(
+        self,
+        path: Optional[str],
+        creds: Dict[str, Any],
+        display_name: str,
+    ) -> Dict[str, Any]:
+        """Perform interactive OpenAI Codex OAuth authorization code flow with PKCE."""
+        is_headless = is_headless_environment()
+
+        # PKCE verifier/challenge (base64url, no padding)
+        code_verifier = (
+            base64.urlsafe_b64encode(secrets.token_bytes(32))
+            .decode("utf-8")
+            .rstrip("=")
+        )
+        code_challenge = (
+            base64.urlsafe_b64encode(
+                hashlib.sha256(code_verifier.encode("utf-8")).digest()
+            )
+            .decode("utf-8")
+            .rstrip("=")
+        )
+        state = secrets.token_hex(32)
+
+        callback_port = get_callback_port()
+        redirect_uri = f"http://localhost:{callback_port}{CALLBACK_PATH}"
+
+        auth_params = {
+            "response_type": "code",
+            "client_id": CLIENT_ID,
+            "redirect_uri": redirect_uri,
+            "scope": SCOPE,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "state": state,
+            "id_token_add_organizations": "true",
+            "codex_cli_simplified_flow": "true",
+            "originator": "pi",
+        }
+        auth_url = f"{AUTHORIZATION_ENDPOINT}?{urlencode(auth_params)}"
+
+        callback_server = OAuthCallbackServer(port=callback_port)
+
+        try:
+            await callback_server.start(expected_state=state)
+
+            if is_headless:
+                help_text = Text.from_markup(
+                    "Running in headless environment.\n"
+                    "Open the URL below in a browser on another machine and complete login."
+                )
+            else:
+                help_text = Text.from_markup(
+                    "Open the URL below, complete sign-in, and return here."
+                )
+
+            console.print(
+                Panel(
+                    help_text,
+                    title=f"OpenAI Codex OAuth Setup for [bold yellow]{display_name}[/bold yellow]",
+                    style="bold blue",
+                )
+            )
+            escaped_url = rich_escape(auth_url)
+            console.print(f"[bold]URL:[/bold] [link={auth_url}]{escaped_url}[/link]\n")
+
+            if not is_headless:
+                try:
+                    webbrowser.open(auth_url)
+                    lib_logger.info("Browser opened for OpenAI Codex OAuth flow")
+                except Exception as e:
+                    lib_logger.warning(
+                        f"Failed to auto-open browser for OpenAI Codex OAuth: {e}"
+                    )
+
+            code = await callback_server.wait_for_callback(
+                timeout=float(self._reauth_timeout_seconds)
+            )
+
+            token_data = await self._exchange_code_for_tokens(
+                code=code,
+                code_verifier=code_verifier,
+                redirect_uri=redirect_uri,
+            )
+
+            # Build updated credential object
+            updated_creds = copy.deepcopy(creds)
+            metadata = updated_creds.setdefault("_proxy_metadata", {})
+            loaded_from_env = metadata.get("loaded_from_env", False)
+            env_index = metadata.get("env_credential_index")
+
+            updated_creds.update(
+                {
+                    "access_token": token_data.get("access_token"),
+                    "refresh_token": token_data.get("refresh_token"),
+                    "id_token": token_data.get("id_token"),
+                    "token_uri": TOKEN_ENDPOINT,
+                    "expiry_date": int(
+                        (time.time() + float(token_data.get("expires_in", 3600))) * 1000
+                    ),
+                }
+            )
+
+            # Restore env metadata flags if this credential originated from env
+            updated_creds.setdefault("_proxy_metadata", {})
+            updated_creds["_proxy_metadata"]["loaded_from_env"] = loaded_from_env
+            updated_creds["_proxy_metadata"]["env_credential_index"] = env_index
+
+            self._ensure_proxy_metadata(updated_creds)
+
+            if path:
+                if not await self._save_credentials(path, updated_creds):
+                    raise IOError(
+                        f"Failed to save OpenAI Codex OAuth credentials for '{display_name}'"
+                    )
+            else:
+                # in-memory setup flow
+                creds.clear()
+                creds.update(updated_creds)
+
+            lib_logger.info(
+                f"OpenAI Codex OAuth initialized successfully for '{display_name}'"
+            )
+            return updated_creds
+
+        finally:
+            await callback_server.stop()
+
+    async def initialize_token(
+        self,
+        creds_or_path: Union[Dict[str, Any], str],
+        force_interactive: bool = False,
+    ) -> Dict[str, Any]:
+        """
+        Initialize OAuth token, refreshing or running interactive flow as needed.
+
+        Interactive re-auth is globally coordinated via ReauthCoordinator so only
+        one flow runs at a time across all providers.
+        """
+        path = creds_or_path if isinstance(creds_or_path, str) else None
+
+        if isinstance(creds_or_path, dict):
+            display_name = creds_or_path.get("_proxy_metadata", {}).get(
+                "display_name", "in-memory OpenAI Codex credential"
+            )
+        else:
+            display_name = Path(path).name if path else "in-memory OpenAI Codex credential"
+
+        try:
+            creds = (
+                await self._load_credentials(creds_or_path) if path else copy.deepcopy(creds_or_path)
+            )
+
+            reason = ""
+            if force_interactive:
+                reason = "interactive re-auth explicitly requested"
+            elif not creds.get("refresh_token"):
+                reason = "refresh token is missing"
+            elif self._is_token_expired(creds):
+                reason = "token is expired"
+
+            if reason:
+                # Prefer non-interactive refresh when we have a refresh token and this is simple expiry
+                if reason == "token is expired" and creds.get("refresh_token") and path:
+                    try:
+                        return await self._refresh_token(path)
+                    except CredentialNeedsReauthError:
+                        # Explicitly fall through into interactive re-auth path
+                        pass
+                    except Exception as e:
+                        lib_logger.warning(
+                            f"Automatic OpenAI Codex token refresh failed for '{display_name}': {e}. Falling back to interactive login."
+                        )
+
+                coordinator = get_reauth_coordinator()
+
+                async def _do_interactive_oauth():
+                    return await self._perform_interactive_oauth(path, creds, display_name)
+
+                result = await coordinator.execute_reauth(
+                    credential_path=path or display_name,
+                    provider_name="OPENAI_CODEX",
+                    reauth_func=_do_interactive_oauth,
+                    timeout=float(self._reauth_timeout_seconds),
+                )
+
+                # Persist cache when path-based
+                if path and isinstance(result, dict):
+                    self._credentials_cache[path] = self._ensure_proxy_metadata(result)
+
+                return result
+
+            # Token is already valid
+            creds = self._ensure_proxy_metadata(creds)
+            if path:
+                self._credentials_cache[path] = creds
+            return creds
+
+        except Exception as e:
+            raise ValueError(
+                f"Failed to initialize OpenAI Codex OAuth credential '{display_name}': {e}"
+            )
+
+    async def get_auth_header(self, credential_identifier: str) -> Dict[str, str]:
+        creds = await self._load_credentials(credential_identifier)
+        if self._is_token_expired(creds):
+            creds = await self._refresh_token(credential_identifier)
+        return {"Authorization": f"Bearer {creds['access_token']}"}
+
+    async def get_user_info(
+        self, creds_or_path: Union[Dict[str, Any], str]
+    ) -> Dict[str, Any]:
+        """Retrieve user info from _proxy_metadata."""
+        try:
+            path = creds_or_path if isinstance(creds_or_path, str) else None
+            creds = await self._load_credentials(path) if path else copy.deepcopy(creds_or_path)
+
+            if path:
+                await self.initialize_token(path)
+                creds = await self._load_credentials(path)
+
+            metadata = creds.get("_proxy_metadata", {})
+            email = metadata.get("email")
+            account_id = metadata.get("account_id")
+
+            # Update timestamp in cache only (non-critical metadata)
+            if path and "_proxy_metadata" in creds:
+                creds["_proxy_metadata"]["last_check_timestamp"] = time.time()
+                self._credentials_cache[path] = creds
+
+            return {
+                "email": email,
+                "account_id": account_id,
+            }
+        except Exception as e:
+            lib_logger.error(f"Failed to get OpenAI Codex user info: {e}")
+            return {"email": None, "account_id": None}
+
+    async def proactively_refresh(self, credential_identifier: str):
+        """Queue proactive refresh for credentials near expiry."""
+        try:
+            creds = await self._load_credentials(credential_identifier)
+        except IOError:
+            return
+
+        if self._is_token_expired(creds):
+            await self._queue_refresh(
+                credential_identifier,
+                force=False,
+                needs_reauth=False,
+            )
+
+    # =========================================================================
+    # Queue + availability plumbing
+    # =========================================================================
+
+    async def _get_lock(self, path: str) -> asyncio.Lock:
+        async with self._locks_lock:
+            if path not in self._refresh_locks:
+                self._refresh_locks[path] = asyncio.Lock()
+            return self._refresh_locks[path]
+
+    def is_credential_available(self, path: str) -> bool:
+        """
+        Check if credential is available for rotation.
+
+        Unavailable when:
+        - In re-auth queue
+        - Truly expired (past actual expiry)
+        """
+        if path in self._unavailable_credentials:
+            marked_time = self._unavailable_credentials.get(path)
+            if marked_time is not None:
+                now = time.time()
+                if now - marked_time > self._unavailable_ttl_seconds:
+                    lib_logger.warning(
+                        f"OpenAI Codex credential '{Path(path).name}' stuck in re-auth queue for {int(now - marked_time)}s. Auto-cleaning stale entry."
+                    )
+                    self._unavailable_credentials.pop(path, None)
+                    self._queued_credentials.discard(path)
+                else:
+                    return False
+
+        creds = self._credentials_cache.get(path)
+        if creds and self._is_token_truly_expired(creds):
+            if path not in self._queued_credentials:
+                try:
+                    loop = asyncio.get_running_loop()
+                    loop.create_task(
+                        self._queue_refresh(path, force=True, needs_reauth=False)
+                    )
+                except RuntimeError:
+                    # No running event loop (e.g., sync context); caller can still
+                    # trigger refresh through normal async request flow.
+                    pass
+            return False
+
+        return True
+
+    async def _ensure_queue_processor_running(self):
+        if self._queue_processor_task is None or self._queue_processor_task.done():
+            self._queue_processor_task = asyncio.create_task(self._process_refresh_queue())
+
+    async def _ensure_reauth_processor_running(self):
+        if self._reauth_processor_task is None or self._reauth_processor_task.done():
+            self._reauth_processor_task = asyncio.create_task(self._process_reauth_queue())
+
+    async def _queue_refresh(
+        self,
+        path: str,
+        force: bool = False,
+        needs_reauth: bool = False,
+    ):
+        """Queue credential for refresh or re-auth."""
+        if not needs_reauth:
+            now = time.time()
+            backoff_until = self._next_refresh_after.get(path)
+            if backoff_until and now < backoff_until:
+                return
+
+        async with self._queue_tracking_lock:
+            if path in self._queued_credentials:
+                return
+
+            self._queued_credentials.add(path)
+
+            if needs_reauth:
+                self._unavailable_credentials[path] = time.time()
+                await self._reauth_queue.put(path)
+                await self._ensure_reauth_processor_running()
+            else:
+                await self._refresh_queue.put((path, force))
+                await self._ensure_queue_processor_running()
+
+    async def _process_refresh_queue(self):
+        """Sequential background worker for normal refresh queue."""
+        while True:
+            path = None
+            try:
+                try:
+                    path, force = await asyncio.wait_for(self._refresh_queue.get(), timeout=60.0)
+                except asyncio.TimeoutError:
+                    async with self._queue_tracking_lock:
+                        self._queue_retry_count.clear()
+                    self._queue_processor_task = None
+                    return
+
+                try:
+                    creds = self._credentials_cache.get(path)
+                    if creds and not self._is_token_expired(creds):
+                        self._queue_retry_count.pop(path, None)
+                        continue
+
+                    try:
+                        async with asyncio.timeout(self._refresh_timeout_seconds):
+                            await self._refresh_token(path, force=force)
+                        self._queue_retry_count.pop(path, None)
+
+                    except asyncio.TimeoutError:
+                        await self._handle_refresh_failure(path, force, "timeout")
+
+                    except httpx.HTTPStatusError as e:
+                        status_code = e.response.status_code
+                        needs_reauth = False
+
+                        if status_code == 400:
+                            try:
+                                payload = e.response.json()
+                                error_type = payload.get("error", "")
+                                error_desc = payload.get("error_description", "")
+                            except Exception:
+                                error_type = ""
+                                error_desc = str(e)
+
+                            if (
+                                error_type == "invalid_grant"
+                                or "invalid_grant" in error_desc.lower()
+                                or "invalid" in error_desc.lower()
+                            ):
+                                needs_reauth = True
+
+                        elif status_code in (401, 403):
+                            needs_reauth = True
+
+                        if needs_reauth:
+                            self._queue_retry_count.pop(path, None)
+                            async with self._queue_tracking_lock:
+                                self._queued_credentials.discard(path)
+                            await self._queue_refresh(path, force=True, needs_reauth=True)
+                        else:
+                            await self._handle_refresh_failure(path, force, f"HTTP {status_code}")
+
+                    except CredentialNeedsReauthError:
+                        self._queue_retry_count.pop(path, None)
+                        async with self._queue_tracking_lock:
+                            self._queued_credentials.discard(path)
+                        await self._queue_refresh(path, force=True, needs_reauth=True)
+
+                    except Exception as e:
+                        await self._handle_refresh_failure(path, force, str(e))
+
+                finally:
+                    async with self._queue_tracking_lock:
+                        if (
+                            path in self._queued_credentials
+                            and self._queue_retry_count.get(path, 0) == 0
+                        ):
+                            self._queued_credentials.discard(path)
+                    self._refresh_queue.task_done()
+
+                await asyncio.sleep(self._refresh_interval_seconds)
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                lib_logger.error(f"Error in OpenAI Codex refresh queue processor: {e}")
+                if path:
+                    async with self._queue_tracking_lock:
+                        self._queued_credentials.discard(path)
+
+    async def _handle_refresh_failure(self, path: str, force: bool, error: str):
+        retry_count = self._queue_retry_count.get(path, 0) + 1
+        self._queue_retry_count[path] = retry_count
+
+        if retry_count >= self._refresh_max_retries:
+            lib_logger.error(
+                f"OpenAI Codex refresh max retries reached for '{Path(path).name}' (last error: {error})."
+            )
+            self._queue_retry_count.pop(path, None)
+            async with self._queue_tracking_lock:
+                self._queued_credentials.discard(path)
+            return
+
+        lib_logger.warning(
+            f"OpenAI Codex refresh failed for '{Path(path).name}' ({error}). Retry {retry_count}/{self._refresh_max_retries}."
+        )
+        await self._refresh_queue.put((path, force))
+
+    async def _process_reauth_queue(self):
+        """Sequential background worker for interactive re-auth queue."""
+        while True:
+            path = None
+            try:
+                try:
+                    path = await asyncio.wait_for(self._reauth_queue.get(), timeout=60.0)
+                except asyncio.TimeoutError:
+                    self._reauth_processor_task = None
+                    return
+
+                try:
+                    lib_logger.info(
+                        f"Starting OpenAI Codex interactive re-auth for '{Path(path).name}'"
+                    )
+                    await self.initialize_token(path, force_interactive=True)
+                    lib_logger.info(
+                        f"OpenAI Codex re-auth succeeded for '{Path(path).name}'"
+                    )
+                except Exception as e:
+                    lib_logger.error(
+                        f"OpenAI Codex re-auth failed for '{Path(path).name}': {e}"
+                    )
+                finally:
+                    async with self._queue_tracking_lock:
+                        self._queued_credentials.discard(path)
+                        self._unavailable_credentials.pop(path, None)
+                    self._reauth_queue.task_done()
+
+            except asyncio.CancelledError:
+                if path:
+                    async with self._queue_tracking_lock:
+                        self._queued_credentials.discard(path)
+                        self._unavailable_credentials.pop(path, None)
+                break
+            except Exception as e:
+                lib_logger.error(f"Error in OpenAI Codex re-auth queue processor: {e}")
+                if path:
+                    async with self._queue_tracking_lock:
+                        self._queued_credentials.discard(path)
+                        self._unavailable_credentials.pop(path, None)
+
+    # =========================================================================
+    # Credential management methods for credential_tool
+    # =========================================================================
+
+    def _get_provider_file_prefix(self) -> str:
+        return "openai_codex"
+
+    def _get_oauth_base_dir(self) -> Path:
+        return Path.cwd() / "oauth_creds"
+
+    def _find_existing_credential_by_identity(
+        self,
+        email: Optional[str],
+        account_id: Optional[str],
+        base_dir: Optional[Path] = None,
+    ) -> Optional[Path]:
+        if base_dir is None:
+            base_dir = self._get_oauth_base_dir()
+
+        prefix = self._get_provider_file_prefix()
+        pattern = str(base_dir / f"{prefix}_oauth_*.json")
+
+        for cred_file in glob(pattern):
+            try:
+                with open(cred_file, "r") as f:
+                    creds = json.load(f)
+                metadata = creds.get("_proxy_metadata", {})
+                existing_email = metadata.get("email")
+                existing_account_id = metadata.get("account_id")
+
+                if email and existing_email and existing_email == email:
+                    return Path(cred_file)
+                if account_id and existing_account_id and existing_account_id == account_id:
+                    return Path(cred_file)
+
+            except Exception:
+                continue
+
+        return None
+
+    def _get_next_credential_number(self, base_dir: Optional[Path] = None) -> int:
+        if base_dir is None:
+            base_dir = self._get_oauth_base_dir()
+
+        prefix = self._get_provider_file_prefix()
+        pattern = str(base_dir / f"{prefix}_oauth_*.json")
+
+        existing_numbers = []
+        for cred_file in glob(pattern):
+            match = re.search(r"_oauth_(\d+)\.json$", cred_file)
+            if match:
+                existing_numbers.append(int(match.group(1)))
+
+        return (max(existing_numbers) + 1) if existing_numbers else 1
+
+    def _build_credential_path(
+        self,
+        base_dir: Optional[Path] = None,
+        number: Optional[int] = None,
+    ) -> Path:
+        if base_dir is None:
+            base_dir = self._get_oauth_base_dir()
+
+        if number is None:
+            number = self._get_next_credential_number(base_dir)
+
+        filename = f"{self._get_provider_file_prefix()}_oauth_{number}.json"
+        return base_dir / filename
+
+    async def setup_credential(
+        self,
+        base_dir: Optional[Path] = None,
+    ) -> OpenAICodexCredentialSetupResult:
+        """Complete OpenAI Codex credential setup flow."""
+        if base_dir is None:
+            base_dir = self._get_oauth_base_dir()
+
+        base_dir.mkdir(parents=True, exist_ok=True)
+
+        try:
+            temp_creds = {
+                "_proxy_metadata": {
+                    "display_name": "new OpenAI Codex credential",
+                    "loaded_from_env": False,
+                    "env_credential_index": None,
+                }
+            }
+            new_creds = await self.initialize_token(temp_creds)
+
+            metadata = new_creds.get("_proxy_metadata", {})
+            email = metadata.get("email")
+            account_id = metadata.get("account_id")
+
+            existing_path = self._find_existing_credential_by_identity(
+                email=email,
+                account_id=account_id,
+                base_dir=base_dir,
+            )
+            is_update = existing_path is not None
+            file_path = existing_path if is_update else self._build_credential_path(base_dir)
+
+            if not await self._save_credentials(str(file_path), new_creds):
+                return OpenAICodexCredentialSetupResult(
+                    success=False,
+                    error=f"Failed to save OpenAI Codex credential to {file_path.name}",
+                )
+
+            return OpenAICodexCredentialSetupResult(
+                success=True,
+                file_path=str(file_path),
+                email=email,
+                is_update=is_update,
+                credentials=new_creds,
+            )
+
+        except Exception as e:
+            lib_logger.error(f"OpenAI Codex credential setup failed: {e}")
+            return OpenAICodexCredentialSetupResult(success=False, error=str(e))
+
+    def build_env_lines(self, creds: Dict[str, Any], cred_number: int) -> List[str]:
+        """Build OPENAI_CODEX_N_* env lines from credential JSON."""
+        metadata = creds.get("_proxy_metadata", {})
+        email = metadata.get("email", "unknown")
+        account_id = metadata.get("account_id", "")
+
+        prefix = f"OPENAI_CODEX_{cred_number}"
+
+        lines = [
+            f"# OPENAI_CODEX Credential #{cred_number} for: {email}",
+            f"# Exported from: openai_codex_oauth_{cred_number}.json",
+            f"# Generated at: {time.strftime('%Y-%m-%d %H:%M:%S')}",
+            "",
+            f"{prefix}_ACCESS_TOKEN={creds.get('access_token', '')}",
+            f"{prefix}_REFRESH_TOKEN={creds.get('refresh_token', '')}",
+            f"{prefix}_EXPIRY_DATE={int(float(creds.get('expiry_date', 0)))}",
+            f"{prefix}_ID_TOKEN={creds.get('id_token', '')}",
+            f"{prefix}_ACCOUNT_ID={account_id}",
+            f"{prefix}_EMAIL={email}",
+        ]
+
+        return lines
+
+    def export_credential_to_env(
+        self,
+        credential_path: str,
+        output_dir: Optional[Path] = None,
+    ) -> Optional[str]:
+        """Export a credential JSON file to .env format."""
+        try:
+            cred_path = Path(credential_path)
+            with open(cred_path, "r") as f:
+                creds = json.load(f)
+
+            metadata = creds.get("_proxy_metadata", {})
+            email = metadata.get("email", "unknown")
+
+            match = re.search(r"_oauth_(\d+)\.json$", cred_path.name)
+            cred_number = int(match.group(1)) if match else 1
+
+            if output_dir is None:
+                output_dir = cred_path.parent
+
+            safe_email = str(email).replace("@", "_at_").replace(".", "_")
+            env_filename = f"openai_codex_{cred_number}_{safe_email}.env"
+            env_path = output_dir / env_filename
+
+            env_lines = self.build_env_lines(creds, cred_number)
+            with open(env_path, "w") as f:
+                f.write("\n".join(env_lines))
+
+            lib_logger.info(f"Exported OpenAI Codex credential to {env_path}")
+            return str(env_path)
+
+        except Exception as e:
+            lib_logger.error(f"Failed to export OpenAI Codex credential: {e}")
+            return None
+
+    def list_credentials(self, base_dir: Optional[Path] = None) -> List[Dict[str, Any]]:
+        """List all local OpenAI Codex credential files."""
+        if base_dir is None:
+            base_dir = self._get_oauth_base_dir()
+
+        prefix = self._get_provider_file_prefix()
+        pattern = str(base_dir / f"{prefix}_oauth_*.json")
+
+        credentials: List[Dict[str, Any]] = []
+        for cred_file in sorted(glob(pattern)):
+            try:
+                with open(cred_file, "r") as f:
+                    creds = json.load(f)
+
+                metadata = creds.get("_proxy_metadata", {})
+                match = re.search(r"_oauth_(\d+)\.json$", cred_file)
+                number = int(match.group(1)) if match else 0
+
+                credentials.append(
+                    {
+                        "file_path": cred_file,
+                        "email": metadata.get("email", "unknown"),
+                        "account_id": metadata.get("account_id"),
+                        "number": number,
+                    }
+                )
+            except Exception:
+                continue
+
+        return credentials
+
+    def delete_credential(self, credential_path: str) -> bool:
+        """Delete an OpenAI Codex credential file."""
+        try:
+            cred_path = Path(credential_path)
+            prefix = self._get_provider_file_prefix()
+
+            if not cred_path.name.startswith(f"{prefix}_oauth_"):
+                lib_logger.error(
+                    f"File {cred_path.name} does not appear to be an OpenAI Codex credential"
+                )
+                return False
+
+            if not cred_path.exists():
+                lib_logger.warning(
+                    f"OpenAI Codex credential file does not exist: {credential_path}"
+                )
+                return False
+
+            self._credentials_cache.pop(credential_path, None)
+            cred_path.unlink()
+            lib_logger.info(f"Deleted OpenAI Codex credential file: {credential_path}")
+            return True
+
+        except Exception as e:
+            lib_logger.error(f"Failed to delete OpenAI Codex credential: {e}")
+            return False

--- a/src/rotator_library/providers/openai_codex_provider.py
+++ b/src/rotator_library/providers/openai_codex_provider.py
@@ -30,9 +30,14 @@ lib_logger = logging.getLogger("rotator_library")
 
 # Conservative fallback model list (can be overridden via OPENAI_CODEX_MODELS)
 HARDCODED_MODELS = [
+    "gpt-5.3-codex",
+    "gpt-5.3-codex-spark",
+    "gpt-5.2-codex",
+    "gpt-5.2",
     "gpt-5.1-codex",
+    "gpt-5.1-codex-max",
+    "gpt-5.1-codex-mini",
     "gpt-5-codex",
-    "gpt-4.1-codex",
 ]
 
 

--- a/src/rotator_library/providers/openai_codex_provider.py
+++ b/src/rotator_library/providers/openai_codex_provider.py
@@ -31,7 +31,6 @@ lib_logger = logging.getLogger("rotator_library")
 # Conservative fallback model list (can be overridden via OPENAI_CODEX_MODELS)
 HARDCODED_MODELS = [
     "gpt-5.3-codex",
-    "gpt-5.3-codex-spark",
     "gpt-5.2-codex",
     "gpt-5.2",
     "gpt-5.1-codex",

--- a/src/rotator_library/providers/openai_codex_provider.py
+++ b/src/rotator_library/providers/openai_codex_provider.py
@@ -812,8 +812,9 @@ class OpenAICodexProvider(OpenAICodexAuthBase, ProviderInterface):
             payload["temperature"] = kwargs["temperature"]
         if kwargs.get("top_p") is not None:
             payload["top_p"] = kwargs["top_p"]
-        if kwargs.get("max_tokens") is not None:
-            payload["max_output_tokens"] = kwargs["max_tokens"]
+        # Note: max_output_tokens is NOT supported by the Codex Responses API
+        # (gpt-5.3-codex returns 400 "Unsupported parameter: max_output_tokens").
+        # Omit it and let the API use its default.
 
         converted_tools = self._convert_tools(kwargs.get("tools"))
         if converted_tools:

--- a/src/rotator_library/providers/openai_codex_provider.py
+++ b/src/rotator_library/providers/openai_codex_provider.py
@@ -1,0 +1,1228 @@
+# SPDX-License-Identifier: LGPL-3.0-only
+# Copyright (c) 2026 Mirrowel
+
+# src/rotator_library/providers/openai_codex_provider.py
+
+import copy
+import json
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, AsyncGenerator, Dict, Iterable, List, Optional, Union
+
+import httpx
+import litellm
+
+from .openai_codex_auth_base import (
+    AUTH_CLAIM,
+    DEFAULT_API_BASE,
+    RESPONSES_ENDPOINT_PATH,
+    OpenAICodexAuthBase,
+)
+from .provider_interface import ProviderInterface, UsageResetConfigDef, QuotaGroupMap
+from ..model_definitions import ModelDefinitions
+from ..timeout_config import TimeoutConfig
+from ..transaction_logger import ProviderLogger
+
+lib_logger = logging.getLogger("rotator_library")
+
+# Conservative fallback model list (can be overridden via OPENAI_CODEX_MODELS)
+HARDCODED_MODELS = [
+    "gpt-5.1-codex",
+    "gpt-5-codex",
+    "gpt-4.1-codex",
+]
+
+
+class CodexStreamError(Exception):
+    """Terminal Codex stream error that should abort the stream."""
+
+    def __init__(self, message: str, status_code: int = 500, error_body: Optional[str] = None):
+        self.status_code = status_code
+        self.error_body = error_body or message
+        super().__init__(message)
+
+
+class CodexSSETranslator:
+    """
+    Translates OpenAI Codex SSE events into OpenAI chat.completion chunks.
+
+    Supports both currently observed events and planned fallback aliases:
+    - response.output_text.delta (observed)
+    - response.content_part.delta (planned alias)
+    - response.function_call_arguments.delta / .done
+    """
+
+    def __init__(self, model_id: str):
+        self.model_id = model_id
+        self.response_id: Optional[str] = None
+        self.created: int = int(time.time())
+        self._tool_index_by_call_id: Dict[str, int] = {}
+        self._tool_names_by_call_id: Dict[str, str] = {}
+
+    def _build_chunk(
+        self,
+        *,
+        delta: Optional[Dict[str, Any]] = None,
+        finish_reason: Optional[str] = None,
+        usage: Optional[Dict[str, int]] = None,
+    ) -> Dict[str, Any]:
+        if not self.response_id:
+            self.response_id = f"chatcmpl-codex-{int(time.time() * 1000)}"
+
+        choice = {
+            "index": 0,
+            "delta": delta or {},
+            "finish_reason": finish_reason,
+        }
+
+        chunk = {
+            "id": self.response_id,
+            "object": "chat.completion.chunk",
+            "created": self.created,
+            "model": self.model_id,
+            "choices": [choice],
+        }
+
+        if usage is not None:
+            chunk["usage"] = usage
+
+        return chunk
+
+    def _extract_text_delta(self, event: Dict[str, Any]) -> Optional[str]:
+        event_type = event.get("type")
+
+        if event_type == "response.output_text.delta":
+            delta = event.get("delta")
+            if isinstance(delta, str):
+                return delta
+
+        if event_type == "response.content_part.delta":
+            # Compatibility with planned taxonomy
+            if isinstance(event.get("delta"), str):
+                return event["delta"]
+            part = event.get("part")
+            if isinstance(part, dict):
+                if isinstance(part.get("delta"), str):
+                    return part["delta"]
+                if isinstance(part.get("text"), str):
+                    return part["text"]
+
+        if event_type == "response.content_part.added":
+            part = event.get("part")
+            if isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str) and text:
+                    return text
+
+        return None
+
+    def _map_incomplete_reason(self, reason: Optional[str]) -> str:
+        if not reason:
+            return "length"
+
+        normalized = reason.strip().lower()
+        if normalized in {"stop", "completed"}:
+            return "stop"
+        if normalized in {"max_output_tokens", "max_tokens", "length"}:
+            return "length"
+        if normalized in {"tool_calls", "tool_call"}:
+            return "tool_calls"
+        if normalized in {"content_filter", "content_filtered"}:
+            return "content_filter"
+        return "length"
+
+    def _extract_usage(self, event: Dict[str, Any]) -> Optional[Dict[str, int]]:
+        response = event.get("response")
+        if not isinstance(response, dict):
+            return None
+
+        usage = response.get("usage")
+        if not isinstance(usage, dict):
+            return None
+
+        prompt_tokens = int(usage.get("input_tokens", 0) or 0)
+        completion_tokens = int(usage.get("output_tokens", 0) or 0)
+        total_tokens = int(usage.get("total_tokens", 0) or 0)
+
+        return {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+        }
+
+    def _get_response_status(self, event: Dict[str, Any]) -> str:
+        response = event.get("response")
+        if isinstance(response, dict):
+            status = response.get("status")
+            if isinstance(status, str) and status:
+                return status
+
+        event_type = event.get("type")
+        if event_type == "response.incomplete":
+            return "incomplete"
+        if event_type == "response.failed":
+            return "failed"
+        return "completed"
+
+    def _get_or_create_tool_index(self, call_id: str) -> int:
+        if call_id not in self._tool_index_by_call_id:
+            self._tool_index_by_call_id[call_id] = len(self._tool_index_by_call_id)
+        return self._tool_index_by_call_id[call_id]
+
+    def _extract_tool_call_id(self, event: Dict[str, Any]) -> Optional[str]:
+        for key in ("call_id", "item_id", "id"):
+            value = event.get(key)
+            if isinstance(value, str) and value:
+                return value
+
+        item = event.get("item")
+        if isinstance(item, dict):
+            for key in ("call_id", "id"):
+                value = item.get(key)
+                if isinstance(value, str) and value:
+                    return value
+
+        return None
+
+    def _extract_error_payload(self, event: Dict[str, Any]) -> Dict[str, Any]:
+        # Common formats:
+        # {type:"error", error:{...}}
+        # {type:"response.failed", response:{error:{...}}}
+        payload = event.get("error")
+        if isinstance(payload, dict):
+            return payload
+
+        response = event.get("response")
+        if isinstance(response, dict):
+            nested = response.get("error")
+            if isinstance(nested, dict):
+                return nested
+
+        return {}
+
+    def _classify_error_status(self, error_payload: Dict[str, Any]) -> int:
+        code = str(error_payload.get("code", "") or "").lower()
+        err_type = str(error_payload.get("type", "") or "").lower()
+        message = str(error_payload.get("message", "") or "").lower()
+        text = " ".join([code, err_type, message])
+
+        if any(token in text for token in ["rate_limit", "usage_limit", "quota"]):
+            return 429
+        if any(token in text for token in ["auth", "unauthorized", "invalid_api_key"]):
+            return 401
+        if "forbidden" in text:
+            return 403
+        if "context" in text or "max_output_tokens" in text:
+            return 400
+        return 500
+
+    def process_event(self, event: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Process a single SSE event and return zero or more translated chunks."""
+        chunks: List[Dict[str, Any]] = []
+
+        event_type = event.get("type")
+        if not isinstance(event_type, str):
+            return chunks
+
+        # Capture response id/created as early as possible
+        response = event.get("response")
+        if isinstance(response, dict):
+            if isinstance(response.get("id"), str) and response.get("id"):
+                self.response_id = response["id"]
+            if isinstance(response.get("created_at"), (int, float)):
+                self.created = int(response["created_at"])
+
+        if event_type == "response.output_item.added":
+            item = event.get("item")
+            if isinstance(item, dict) and item.get("type") == "function_call":
+                call_id = self._extract_tool_call_id(item)
+                if call_id:
+                    index = self._get_or_create_tool_index(call_id)
+                    name = item.get("name") if isinstance(item.get("name"), str) else ""
+                    if name:
+                        self._tool_names_by_call_id[call_id] = name
+
+                    initial_args = item.get("arguments")
+                    if not isinstance(initial_args, str):
+                        initial_args = ""
+
+                    tool_delta = {
+                        "tool_calls": [
+                            {
+                                "index": index,
+                                "id": call_id,
+                                "type": "function",
+                                "function": {
+                                    "name": name,
+                                    "arguments": initial_args,
+                                },
+                            }
+                        ]
+                    }
+                    chunks.append(self._build_chunk(delta=tool_delta))
+            return chunks
+
+        if event_type == "response.function_call_arguments.delta":
+            call_id = self._extract_tool_call_id(event)
+            delta = event.get("delta")
+            if call_id and isinstance(delta, str):
+                index = self._get_or_create_tool_index(call_id)
+                name = self._tool_names_by_call_id.get(call_id, "")
+                tool_delta = {
+                    "tool_calls": [
+                        {
+                            "index": index,
+                            "id": call_id,
+                            "type": "function",
+                            "function": {
+                                "name": name,
+                                "arguments": delta,
+                            },
+                        }
+                    ]
+                }
+                chunks.append(self._build_chunk(delta=tool_delta))
+            return chunks
+
+        if event_type == "response.function_call_arguments.done":
+            call_id = self._extract_tool_call_id(event)
+            if call_id:
+                index = self._get_or_create_tool_index(call_id)
+                name = self._tool_names_by_call_id.get(call_id, "")
+                arguments = event.get("arguments")
+                if not isinstance(arguments, str):
+                    arguments = ""
+
+                tool_delta = {
+                    "tool_calls": [
+                        {
+                            "index": index,
+                            "id": call_id,
+                            "type": "function",
+                            "function": {
+                                "name": name,
+                                "arguments": arguments,
+                            },
+                        }
+                    ]
+                }
+                chunks.append(self._build_chunk(delta=tool_delta))
+            return chunks
+
+        text_delta = self._extract_text_delta(event)
+        if text_delta:
+            chunks.append(self._build_chunk(delta={"content": text_delta}))
+            return chunks
+
+        if event_type in ("error", "response.failed"):
+            error_payload = self._extract_error_payload(event)
+            status_code = self._classify_error_status(error_payload)
+            message = (
+                error_payload.get("message")
+                if isinstance(error_payload.get("message"), str)
+                else f"Codex stream failed ({event_type})"
+            )
+            raise CodexStreamError(
+                message=message,
+                status_code=status_code,
+                error_body=json.dumps({"error": error_payload} if error_payload else event),
+            )
+
+        if event_type in ("response.completed", "response.incomplete"):
+            usage = self._extract_usage(event)
+            status = self._get_response_status(event)
+            finish_reason = "stop"
+
+            if status == "incomplete":
+                incomplete_details = None
+                if isinstance(response, dict):
+                    incomplete_details = response.get("incomplete_details")
+                reason = None
+                if isinstance(incomplete_details, dict):
+                    reason = incomplete_details.get("reason")
+                if isinstance(reason, str):
+                    finish_reason = self._map_incomplete_reason(reason)
+                else:
+                    finish_reason = "length"
+
+            chunks.append(
+                self._build_chunk(delta={}, finish_reason=finish_reason, usage=usage)
+            )
+            return chunks
+
+        # Ignore all other event families safely
+        return chunks
+
+
+class OpenAICodexProvider(OpenAICodexAuthBase, ProviderInterface):
+    """OpenAI Codex provider via ChatGPT backend `/codex/responses`."""
+
+    skip_cost_calculation = True
+    default_rotation_mode: str = "sequential"
+    provider_env_name: str = "openai_codex"
+
+    # Conservative placeholders (MVP-safe defaults)
+    tier_priorities = {
+        "unknown": 10,
+    }
+
+    usage_reset_configs = {
+        "default": UsageResetConfigDef(
+            window_seconds=24 * 60 * 60,
+            mode="credential",
+            description="TODO: tune OpenAI Codex quota window from observed behavior",
+            field_name="daily",
+        )
+    }
+
+    model_quota_groups: QuotaGroupMap = {
+        # TODO: tune once quota sharing behavior is empirically validated
+    }
+
+    def __init__(self):
+        super().__init__()
+        self.model_definitions = ModelDefinitions()
+
+    def has_custom_logic(self) -> bool:
+        return True
+
+    # =========================================================================
+    # Model discovery
+    # =========================================================================
+
+    async def get_models(self, credential: str, client: httpx.AsyncClient) -> List[str]:
+        """
+        Returns OpenAI Codex models from:
+        1) OPENAI_CODEX_MODELS env definitions (priority)
+        2) hardcoded fallback list
+        3) optional dynamic /models discovery (best-effort)
+        """
+        models: List[str] = []
+        env_model_ids = set()
+
+        static_models = self.model_definitions.get_all_provider_models("openai_codex")
+        if static_models:
+            for model in static_models:
+                model_name = model.split("/")[-1] if "/" in model else model
+                model_id = self.model_definitions.get_model_id("openai_codex", model_name)
+                models.append(model)
+                if model_id:
+                    env_model_ids.add(model_id)
+
+            lib_logger.info(
+                f"Loaded {len(static_models)} static models for openai_codex from OPENAI_CODEX_MODELS"
+            )
+
+        for model_id in HARDCODED_MODELS:
+            if model_id not in env_model_ids:
+                models.append(f"openai_codex/{model_id}")
+                env_model_ids.add(model_id)
+
+        # Optional dynamic discovery (Codex backend may not support this endpoint)
+        try:
+            await self.initialize_token(credential)
+            creds = await self._load_credentials(credential)
+            access_token, account_id = self._extract_runtime_auth(creds)
+
+            api_base = self._resolve_api_base()
+            models_url = f"{api_base.rstrip('/')}/models"
+
+            headers = self._build_request_headers(
+                access_token=access_token,
+                account_id=account_id,
+                stream=False,
+            )
+
+            response = await client.get(models_url, headers=headers, timeout=20.0)
+            response.raise_for_status()
+
+            payload = response.json()
+            data = payload.get("data") if isinstance(payload, dict) else payload
+
+            discovered = 0
+            if isinstance(data, list):
+                for item in data:
+                    model_id = None
+                    if isinstance(item, dict):
+                        model_id = item.get("id") or item.get("name")
+                    elif isinstance(item, str):
+                        model_id = item
+
+                    if isinstance(model_id, str) and model_id and model_id not in env_model_ids:
+                        models.append(f"openai_codex/{model_id}")
+                        env_model_ids.add(model_id)
+                        discovered += 1
+
+            if discovered > 0:
+                lib_logger.debug(
+                    f"Discovered {discovered} additional models for openai_codex via dynamic /models"
+                )
+
+        except Exception as e:
+            lib_logger.debug(f"Dynamic model discovery failed for openai_codex: {e}")
+
+        return models
+
+    async def initialize_credentials(self, credential_paths: List[str]) -> None:
+        """Preload credentials and queue refresh/reauth where needed."""
+        ready = 0
+        refreshing = 0
+        reauth_required = 0
+
+        for cred_path in credential_paths:
+            try:
+                creds = await self._load_credentials(cred_path)
+                self._ensure_proxy_metadata(creds)
+
+                if not creds.get("refresh_token"):
+                    await self._queue_refresh(cred_path, force=True, needs_reauth=True)
+                    reauth_required += 1
+                    continue
+
+                if self._is_token_expired(creds):
+                    await self._queue_refresh(cred_path, force=False, needs_reauth=False)
+                    refreshing += 1
+                else:
+                    ready += 1
+
+                # ensure metadata caches are populated
+                self._credentials_cache[cred_path] = creds
+
+            except Exception as e:
+                lib_logger.warning(
+                    f"Failed to initialize OpenAI Codex credential '{cred_path}': {e}"
+                )
+                await self._queue_refresh(cred_path, force=True, needs_reauth=True)
+                reauth_required += 1
+
+        lib_logger.info(
+            "OpenAI Codex credential initialization: "
+            f"ready={ready}, refreshing={refreshing}, reauth_required={reauth_required}"
+        )
+
+    # =========================================================================
+    # Request mapping helpers
+    # =========================================================================
+
+    def _resolve_api_base(self) -> str:
+        return os.getenv("OPENAI_CODEX_API_BASE", DEFAULT_API_BASE)
+
+    def _extract_runtime_auth(self, creds: Dict[str, Any]) -> Tuple[str, str]:
+        access_token = creds.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            raise ValueError("OpenAI Codex credential missing access_token")
+
+        metadata = creds.get("_proxy_metadata", {})
+        account_id = metadata.get("account_id")
+
+        if not account_id:
+            # Fallback parse from access_token
+            payload = self._decode_jwt_unverified(access_token)
+            if payload:
+                direct = payload.get("https://api.openai.com/auth.chatgpt_account_id")
+                nested = None
+                claim = payload.get(AUTH_CLAIM)
+                if isinstance(claim, dict):
+                    nested = claim.get("chatgpt_account_id")
+
+                account_id = direct or nested
+
+        if not isinstance(account_id, str) or not account_id:
+            raise ValueError(
+                "OpenAI Codex credential missing account_id. Re-authenticate to refresh token metadata."
+            )
+
+        return access_token, account_id
+
+    def _build_request_headers(
+        self,
+        *,
+        access_token: str,
+        account_id: str,
+        stream: bool,
+        extra_headers: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, str]:
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "chatgpt-account-id": account_id,
+            "OpenAI-Beta": "responses=experimental",
+            "originator": "pi",
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream" if stream else "application/json",
+            "User-Agent": "LLM-API-Key-Proxy/OpenAICodex",
+        }
+
+        if extra_headers:
+            headers.update({k: str(v) for k, v in extra_headers.items()})
+
+        return headers
+
+    def _extract_text(self, content: Any) -> str:
+        if content is None:
+            return ""
+
+        if isinstance(content, str):
+            return content
+
+        if isinstance(content, list):
+            parts: List[str] = []
+            for item in content:
+                if isinstance(item, dict):
+                    # OpenAI chat content blocks
+                    if item.get("type") == "text" and isinstance(item.get("text"), str):
+                        parts.append(item["text"])
+                    elif item.get("type") in {"input_text", "output_text"} and isinstance(
+                        item.get("text"), str
+                    ):
+                        parts.append(item["text"])
+                    elif item.get("type") == "refusal" and isinstance(item.get("refusal"), str):
+                        parts.append(item["refusal"])
+                elif isinstance(item, str):
+                    parts.append(item)
+            return "\n".join(parts)
+
+        if isinstance(content, dict):
+            if isinstance(content.get("text"), str):
+                return content["text"]
+            return json.dumps(content)
+
+        return str(content)
+
+    def _convert_user_content_to_input_parts(self, content: Any) -> List[Dict[str, Any]]:
+        if isinstance(content, str):
+            return [{"type": "input_text", "text": content}]
+
+        if isinstance(content, list):
+            parts: List[Dict[str, Any]] = []
+            for item in content:
+                if not isinstance(item, dict):
+                    continue
+
+                item_type = item.get("type")
+                if item_type in ("text", "input_text") and isinstance(item.get("text"), str):
+                    parts.append({"type": "input_text", "text": item["text"]})
+                elif item_type == "image_url":
+                    image_url = item.get("image_url")
+                    if isinstance(image_url, dict):
+                        image_url = image_url.get("url")
+                    if isinstance(image_url, str) and image_url:
+                        parts.append({"type": "input_image", "image_url": image_url, "detail": "auto"})
+                elif item_type == "input_image":
+                    image_url = item.get("image_url")
+                    if isinstance(image_url, str) and image_url:
+                        part = {"type": "input_image", "image_url": image_url}
+                        if isinstance(item.get("detail"), str):
+                            part["detail"] = item["detail"]
+                        else:
+                            part["detail"] = "auto"
+                        parts.append(part)
+
+            if parts:
+                return parts
+
+        text = self._extract_text(content)
+        return [{"type": "input_text", "text": text}]
+
+    def _convert_messages_to_codex_input(
+        self,
+        messages: List[Dict[str, Any]],
+    ) -> Tuple[str, List[Dict[str, Any]]]:
+        instructions: List[str] = []
+        codex_input: List[Dict[str, Any]] = []
+
+        for message in messages:
+            role = message.get("role")
+            content = message.get("content")
+
+            if role in ("system", "developer"):
+                text = self._extract_text(content)
+                if text.strip():
+                    instructions.append(text.strip())
+                continue
+
+            if role == "user":
+                codex_input.append(
+                    {
+                        "role": "user",
+                        "content": self._convert_user_content_to_input_parts(content),
+                    }
+                )
+                continue
+
+            if role == "assistant":
+                text = self._extract_text(content)
+                if text.strip():
+                    codex_input.append(
+                        {
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": text}],
+                        }
+                    )
+
+                # Carry forward assistant tool calls where provided
+                tool_calls = message.get("tool_calls")
+                if isinstance(tool_calls, list):
+                    for tool_call in tool_calls:
+                        if not isinstance(tool_call, dict):
+                            continue
+
+                        call_id = tool_call.get("id")
+                        function = tool_call.get("function", {})
+                        if not isinstance(function, dict):
+                            continue
+
+                        name = function.get("name")
+                        arguments = function.get("arguments")
+                        if not isinstance(arguments, str):
+                            arguments = json.dumps(arguments or {})
+
+                        if isinstance(call_id, str) and isinstance(name, str):
+                            codex_input.append(
+                                {
+                                    "type": "function_call",
+                                    "call_id": call_id,
+                                    "name": name,
+                                    "arguments": arguments,
+                                }
+                            )
+                continue
+
+            if role == "tool":
+                call_id = message.get("tool_call_id")
+                if not isinstance(call_id, str) or not call_id:
+                    continue
+
+                output_text = self._extract_text(content)
+                codex_input.append(
+                    {
+                        "type": "function_call_output",
+                        "call_id": call_id,
+                        "output": output_text,
+                    }
+                )
+
+        # Codex endpoint currently requires non-empty instructions
+        instructions_text = "\n\n".join(instructions).strip()
+        if not instructions_text:
+            instructions_text = "You are a helpful assistant."
+
+        if not codex_input:
+            codex_input = [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": "",
+                        }
+                    ],
+                }
+            ]
+
+        return instructions_text, codex_input
+
+    def _convert_tools(self, tools: Any) -> Optional[List[Dict[str, Any]]]:
+        if not isinstance(tools, list) or not tools:
+            return None
+
+        converted: List[Dict[str, Any]] = []
+
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+
+            # OpenAI chat format: {type:"function", function:{name,description,parameters}}
+            if tool.get("type") == "function" and isinstance(tool.get("function"), dict):
+                fn = tool["function"]
+                name = fn.get("name")
+                if not isinstance(name, str) or not name:
+                    continue
+
+                schema = fn.get("parameters")
+                if not isinstance(schema, dict):
+                    schema = {"type": "object", "properties": {}}
+
+                # Remove OpenAI-specific strict flag if present
+                schema = copy.deepcopy(schema)
+                schema.pop("additionalProperties", None)
+
+                converted.append(
+                    {
+                        "type": "function",
+                        "name": name,
+                        "description": fn.get("description", ""),
+                        "parameters": schema,
+                    }
+                )
+                continue
+
+            # Already in responses format
+            if tool.get("type") == "function" and isinstance(tool.get("name"), str):
+                converted.append(copy.deepcopy(tool))
+
+        return converted or None
+
+    def _normalize_tool_choice(self, tool_choice: Any, has_tools: bool) -> Any:
+        if not has_tools:
+            return None
+
+        if isinstance(tool_choice, str):
+            # Codex endpoint handles "auto" reliably; map required -> auto
+            if tool_choice in {"auto", "none"}:
+                return tool_choice
+            if tool_choice == "required":
+                return "auto"
+            return "auto"
+
+        if isinstance(tool_choice, dict):
+            if tool_choice.get("type") == "function":
+                fn = tool_choice.get("function")
+                if isinstance(fn, dict) and isinstance(fn.get("name"), str):
+                    return {"type": "function", "name": fn["name"]}
+                if isinstance(tool_choice.get("name"), str):
+                    return {"type": "function", "name": tool_choice["name"]}
+            if isinstance(tool_choice.get("name"), str):
+                return {"type": "function", "name": tool_choice["name"]}
+
+        return "auto"
+
+    def _build_codex_payload(self, model_name: str, **kwargs) -> Dict[str, Any]:
+        messages = kwargs.get("messages") or []
+        instructions, codex_input = self._convert_messages_to_codex_input(messages)
+
+        payload: Dict[str, Any] = {
+            "model": model_name,
+            "stream": True,  # Endpoint currently requires stream=true
+            "store": False,
+            "instructions": instructions,
+            "input": codex_input,
+            "tool_choice": "auto",
+            "parallel_tool_calls": True,
+        }
+
+        # Keep verbosity at medium by default (gpt-5.1-codex rejects low)
+        text_verbosity = os.getenv("OPENAI_CODEX_TEXT_VERBOSITY", "medium")
+        payload["text"] = {"verbosity": text_verbosity}
+
+        # OpenAI chat params -> Codex responses equivalents
+        if kwargs.get("temperature") is not None:
+            payload["temperature"] = kwargs["temperature"]
+        if kwargs.get("top_p") is not None:
+            payload["top_p"] = kwargs["top_p"]
+        if kwargs.get("max_tokens") is not None:
+            payload["max_output_tokens"] = kwargs["max_tokens"]
+
+        converted_tools = self._convert_tools(kwargs.get("tools"))
+        if converted_tools:
+            payload["tools"] = converted_tools
+            payload["tool_choice"] = self._normalize_tool_choice(
+                kwargs.get("tool_choice"),
+                has_tools=True,
+            )
+            payload["parallel_tool_calls"] = True
+        else:
+            payload.pop("tools", None)
+            payload.pop("tool_choice", None)
+            payload.pop("parallel_tool_calls", None)
+
+        # Optional session pinning for cache affinity
+        session_id = kwargs.get("session_id") or kwargs.get("conversation_id")
+        if isinstance(session_id, str) and session_id:
+            payload["prompt_cache_key"] = session_id
+            payload["prompt_cache_retention"] = "in-memory"
+
+        return payload
+
+    # =========================================================================
+    # SSE parsing + response conversion
+    # =========================================================================
+
+    async def _iter_sse_events(
+        self, response: httpx.Response
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        """Parse SSE stream into event dictionaries."""
+        event_lines: List[str] = []
+
+        async for line in response.aiter_lines():
+            if line is None:
+                continue
+
+            if line == "":
+                if not event_lines:
+                    continue
+
+                data_lines = []
+                for entry in event_lines:
+                    if entry.startswith("data:"):
+                        data_lines.append(entry[5:].lstrip())
+
+                event_lines = []
+                if not data_lines:
+                    continue
+
+                payload = "\n".join(data_lines).strip()
+                if not payload or payload == "[DONE]":
+                    if payload == "[DONE]":
+                        return
+                    continue
+
+                try:
+                    parsed = json.loads(payload)
+                    if isinstance(parsed, dict):
+                        yield parsed
+                except json.JSONDecodeError:
+                    lib_logger.debug(f"OpenAI Codex SSE non-JSON payload ignored: {payload[:200]}")
+                continue
+
+            event_lines.append(line)
+
+        # Flush trailing event if stream closes without blank line
+        if event_lines:
+            data_lines = [entry[5:].lstrip() for entry in event_lines if entry.startswith("data:")]
+            payload = "\n".join(data_lines).strip()
+            if payload and payload != "[DONE]":
+                try:
+                    parsed = json.loads(payload)
+                    if isinstance(parsed, dict):
+                        yield parsed
+                except json.JSONDecodeError:
+                    pass
+
+    def _stream_to_completion_response(
+        self, chunks: List[litellm.ModelResponse]
+    ) -> litellm.ModelResponse:
+        """Reassemble streamed chunks into a non-streaming ModelResponse."""
+        if not chunks:
+            raise ValueError("No chunks provided for reassembly")
+
+        final_message: Dict[str, Any] = {"role": "assistant"}
+        aggregated_tool_calls: Dict[int, Dict[str, Any]] = {}
+        usage_data = None
+        chunk_finish_reason = None
+
+        first_chunk = chunks[0]
+
+        for chunk in chunks:
+            if not hasattr(chunk, "choices") or not chunk.choices:
+                continue
+
+            choice = chunk.choices[0]
+            delta = choice.get("delta", {})
+
+            if "content" in delta and delta["content"] is not None:
+                final_message["content"] = final_message.get("content", "") + delta["content"]
+
+            if "tool_calls" in delta and delta["tool_calls"]:
+                for tc_chunk in delta["tool_calls"]:
+                    index = tc_chunk.get("index", 0)
+                    if index not in aggregated_tool_calls:
+                        aggregated_tool_calls[index] = {
+                            "type": "function",
+                            "function": {"name": "", "arguments": ""},
+                        }
+
+                    if tc_chunk.get("id"):
+                        aggregated_tool_calls[index]["id"] = tc_chunk["id"]
+
+                    if tc_chunk.get("type"):
+                        aggregated_tool_calls[index]["type"] = tc_chunk["type"]
+
+                    if isinstance(tc_chunk.get("function"), dict):
+                        fn = tc_chunk["function"]
+                        if fn.get("name") is not None:
+                            aggregated_tool_calls[index]["function"]["name"] += str(fn["name"])
+                        if fn.get("arguments") is not None:
+                            aggregated_tool_calls[index]["function"]["arguments"] += str(
+                                fn["arguments"]
+                            )
+
+            if choice.get("finish_reason"):
+                chunk_finish_reason = choice["finish_reason"]
+
+        for chunk in reversed(chunks):
+            if hasattr(chunk, "usage") and chunk.usage:
+                usage_data = chunk.usage
+                break
+
+        if aggregated_tool_calls:
+            final_message["tool_calls"] = list(aggregated_tool_calls.values())
+
+        for field in ["content", "tool_calls", "function_call"]:
+            if field not in final_message:
+                final_message[field] = None
+
+        if aggregated_tool_calls:
+            finish_reason = "tool_calls"
+        elif chunk_finish_reason:
+            finish_reason = chunk_finish_reason
+        else:
+            finish_reason = "stop"
+
+        final_choice = {
+            "index": 0,
+            "message": final_message,
+            "finish_reason": finish_reason,
+        }
+
+        final_response_data = {
+            "id": first_chunk.id,
+            "object": "chat.completion",
+            "created": first_chunk.created,
+            "model": first_chunk.model,
+            "choices": [final_choice],
+            "usage": usage_data,
+        }
+
+        return litellm.ModelResponse(**final_response_data)
+
+    # =========================================================================
+    # Main completion flow
+    # =========================================================================
+
+    async def acompletion(
+        self, client: httpx.AsyncClient, **kwargs
+    ) -> Union[litellm.ModelResponse, AsyncGenerator[litellm.ModelResponse, None]]:
+        credential_identifier = kwargs.pop("credential_identifier")
+        transaction_context = kwargs.pop("transaction_context", None)
+        model = kwargs["model"]
+
+        file_logger = ProviderLogger(transaction_context)
+
+        async def make_request() -> Any:
+            # Ensure token initialized/refreshed before request
+            await self.initialize_token(credential_identifier)
+            creds = await self._load_credentials(credential_identifier)
+            if self._is_token_expired(creds):
+                creds = await self._refresh_token(credential_identifier)
+
+            access_token, account_id = self._extract_runtime_auth(creds)
+
+            model_name = model.split("/")[-1]
+            payload = self._build_codex_payload(model_name=model_name, **kwargs)
+
+            headers = self._build_request_headers(
+                access_token=access_token,
+                account_id=account_id,
+                stream=True,
+            )
+
+            url = f"{self._resolve_api_base().rstrip('/')}{RESPONSES_ENDPOINT_PATH}"
+            file_logger.log_request(payload)
+
+            return client.stream(
+                "POST",
+                url,
+                headers=headers,
+                json=payload,
+                timeout=TimeoutConfig.streaming(),
+            )
+
+        async def stream_handler(
+            response_stream: Any,
+            attempt: int = 1,
+        ):
+            try:
+                async with response_stream as response:
+                    if response.status_code >= 400:
+                        raw_error = await response.aread()
+                        error_text = (
+                            raw_error.decode("utf-8", "replace")
+                            if isinstance(raw_error, bytes)
+                            else str(raw_error)
+                        )
+
+                        # Try a single forced token refresh on auth failures
+                        if response.status_code in (401, 403) and attempt == 1:
+                            lib_logger.warning(
+                                "OpenAI Codex returned 401/403; forcing refresh and retrying once"
+                            )
+                            await self._refresh_token(credential_identifier, force=True)
+                            retry_stream = await make_request()
+                            async for chunk in stream_handler(retry_stream, attempt=2):
+                                yield chunk
+                            return
+
+                        # Surface typed HTTPStatusError for classify_error()
+                        raise httpx.HTTPStatusError(
+                            f"OpenAI Codex HTTP {response.status_code}: {error_text}",
+                            request=response.request,
+                            response=response,
+                        )
+
+                    translator = CodexSSETranslator(model_id=model)
+
+                    async for event in self._iter_sse_events(response):
+                        try:
+                            file_logger.log_response_chunk(json.dumps(event))
+                        except Exception:
+                            pass
+
+                        try:
+                            translated_chunks = translator.process_event(event)
+                        except CodexStreamError as stream_error:
+                            synthetic_response = httpx.Response(
+                                status_code=stream_error.status_code,
+                                request=response.request,
+                                text=stream_error.error_body,
+                            )
+                            raise httpx.HTTPStatusError(
+                                str(stream_error),
+                                request=response.request,
+                                response=synthetic_response,
+                            )
+
+                        for chunk_dict in translated_chunks:
+                            yield litellm.ModelResponse(**chunk_dict)
+
+            except httpx.HTTPStatusError:
+                raise
+            except Exception as e:
+                file_logger.log_error(f"Error during OpenAI Codex stream processing: {e}")
+                raise
+
+        async def logging_stream_wrapper():
+            chunks: List[litellm.ModelResponse] = []
+            try:
+                async for chunk in stream_handler(await make_request()):
+                    chunks.append(chunk)
+                    yield chunk
+            finally:
+                if chunks:
+                    try:
+                        final_response = self._stream_to_completion_response(chunks)
+                        if hasattr(final_response, "model_dump"):
+                            file_logger.log_final_response(final_response.model_dump())
+                        else:
+                            file_logger.log_final_response(final_response.dict())
+                    except Exception:
+                        pass
+
+        if kwargs.get("stream"):
+            return logging_stream_wrapper()
+
+        async def non_stream_wrapper() -> litellm.ModelResponse:
+            chunks = [chunk async for chunk in logging_stream_wrapper()]
+            return self._stream_to_completion_response(chunks)
+
+        return await non_stream_wrapper()
+
+    # =========================================================================
+    # Provider-specific quota parsing
+    # =========================================================================
+
+    @staticmethod
+    def parse_quota_error(
+        error: Exception,
+        error_body: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Parse OpenAI Codex quota/rate-limit errors.
+
+        Supports:
+        - Retry-After header
+        - error.resets_at (unix seconds)
+        - error.retry_after / retry_after_seconds fields
+        - usage_limit / quota / rate_limit style error codes
+        """
+        now_ts = time.time()
+
+        response = None
+        if isinstance(error, httpx.HTTPStatusError):
+            response = error.response
+
+        headers = response.headers if response is not None else {}
+
+        retry_after: Optional[int] = None
+        retry_header = headers.get("Retry-After") or headers.get("retry-after")
+        if retry_header:
+            try:
+                retry_after = max(1, int(float(retry_header)))
+            except ValueError:
+                retry_after = None
+
+        body_text = error_body
+        if body_text is None and response is not None:
+            try:
+                body_text = response.text
+            except Exception:
+                body_text = None
+
+        if not body_text:
+            if retry_after is not None:
+                return {
+                    "retry_after": retry_after,
+                    "reason": "RATE_LIMIT",
+                    "reset_timestamp": None,
+                    "quota_reset_timestamp": None,
+                }
+            return None
+
+        parsed = None
+        try:
+            parsed = json.loads(body_text)
+        except Exception:
+            parsed = None
+
+        if not isinstance(parsed, dict):
+            if retry_after is not None:
+                return {
+                    "retry_after": retry_after,
+                    "reason": "RATE_LIMIT",
+                    "reset_timestamp": None,
+                    "quota_reset_timestamp": None,
+                }
+            return None
+
+        err = parsed.get("error") if isinstance(parsed.get("error"), dict) else {}
+
+        code = str(err.get("code", "") or "").lower()
+        err_type = str(err.get("type", "") or "").lower()
+        message = str(err.get("message", "") or "").lower()
+        combined = " ".join([code, err_type, message])
+
+        # Look for codex-specific reset timestamp
+        reset_ts = err.get("resets_at")
+        quota_reset_timestamp: Optional[float] = None
+        reset_timestamp_iso: Optional[str] = None
+        if isinstance(reset_ts, (int, float)):
+            quota_reset_timestamp = float(reset_ts)
+            retry_after_from_reset = int(max(1, quota_reset_timestamp - now_ts))
+            retry_after = retry_after or retry_after_from_reset
+            reset_timestamp_iso = datetime.fromtimestamp(
+                quota_reset_timestamp, tz=timezone.utc
+            ).isoformat()
+
+        if retry_after is None:
+            for key in ("retry_after", "retry_after_seconds", "retryAfter"):
+                value = err.get(key)
+                if isinstance(value, (int, float)):
+                    retry_after = max(1, int(value))
+                    break
+                if isinstance(value, str):
+                    try:
+                        retry_after = max(1, int(float(value)))
+                        break
+                    except ValueError:
+                        continue
+
+        if retry_after is None and any(
+            token in combined for token in ["usage_limit", "rate_limit", "quota"]
+        ):
+            retry_after = 60
+
+        if retry_after is None:
+            return None
+
+        reason = (
+            str(err.get("code") or err.get("type") or "RATE_LIMIT").upper()
+        )
+
+        return {
+            "retry_after": retry_after,
+            "reason": reason,
+            "reset_timestamp": reset_timestamp_iso,
+            "quota_reset_timestamp": quota_reset_timestamp,
+        }

--- a/src/rotator_library/utils/__init__.py
+++ b/src/rotator_library/utils/__init__.py
@@ -20,6 +20,15 @@ from .resilient_io import (
     safe_read_json,
     safe_mkdir,
 )
+from .openai_codex_jwt import (
+    AUTH_CLAIM,
+    ACCOUNT_ID_CLAIM,
+    decode_jwt_unverified,
+    extract_account_id_from_payload,
+    extract_explicit_email_from_payload,
+    extract_email_from_payload,
+    extract_expiry_ms_from_payload,
+)
 from .suppress_litellm_warnings import suppress_litellm_serialization_warnings
 
 __all__ = [
@@ -37,5 +46,12 @@ __all__ = [
     "safe_log_write",
     "safe_read_json",
     "safe_mkdir",
+    "AUTH_CLAIM",
+    "ACCOUNT_ID_CLAIM",
+    "decode_jwt_unverified",
+    "extract_account_id_from_payload",
+    "extract_explicit_email_from_payload",
+    "extract_email_from_payload",
+    "extract_expiry_ms_from_payload",
     "suppress_litellm_serialization_warnings",
 ]

--- a/src/rotator_library/utils/openai_codex_jwt.py
+++ b/src/rotator_library/utils/openai_codex_jwt.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: LGPL-3.0-only
+# Copyright (c) 2026 Mirrowel
+
+"""Shared JWT parsing helpers for OpenAI Codex OAuth credentials.
+
+These helpers intentionally decode JWT payloads without signature verification.
+They are only used for non-authoritative metadata extraction (account/email/exp),
+not for auth decisions.
+"""
+
+import base64
+import json
+from typing import Any, Dict, Optional
+
+AUTH_CLAIM = "https://api.openai.com/auth"
+ACCOUNT_ID_CLAIM = "https://api.openai.com/auth.chatgpt_account_id"
+
+
+def decode_jwt_unverified(token: str) -> Optional[Dict[str, Any]]:
+    """Decode JWT payload without signature verification."""
+    if not token or not isinstance(token, str):
+        return None
+
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+
+    payload_segment = parts[1]
+    padding = "=" * (-len(payload_segment) % 4)
+
+    try:
+        payload_bytes = base64.urlsafe_b64decode(payload_segment + padding)
+        payload = json.loads(payload_bytes.decode("utf-8"))
+        return payload if isinstance(payload, dict) else None
+    except Exception:
+        return None
+
+
+def extract_account_id_from_payload(payload: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Extract account ID from known OpenAI Codex JWT claim locations."""
+    if not payload:
+        return None
+
+    # 1) Direct dotted claim format
+    direct = payload.get(ACCOUNT_ID_CLAIM)
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+
+    # 2) Nested object claim format observed in real tokens
+    auth_claim = payload.get(AUTH_CLAIM)
+    if isinstance(auth_claim, dict):
+        nested = auth_claim.get("chatgpt_account_id")
+        if isinstance(nested, str) and nested.strip():
+            return nested.strip()
+
+    # 3) Fallback organizations[0].id if present
+    orgs = payload.get("organizations")
+    if isinstance(orgs, list) and orgs:
+        first = orgs[0]
+        if isinstance(first, dict):
+            org_id = first.get("id")
+            if isinstance(org_id, str) and org_id.strip():
+                return org_id.strip()
+
+    return None
+
+
+def extract_explicit_email_from_payload(payload: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Extract explicit email claim only (no subject fallback)."""
+    if not payload:
+        return None
+
+    email = payload.get("email")
+    if isinstance(email, str) and email.strip():
+        return email.strip()
+
+    return None
+
+
+def extract_email_from_payload(payload: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Extract email fallback chain: email -> sub."""
+    if not payload:
+        return None
+
+    email = extract_explicit_email_from_payload(payload)
+    if email:
+        return email
+
+    sub = payload.get("sub")
+    if isinstance(sub, str) and sub.strip():
+        return sub.strip()
+
+    return None
+
+
+def extract_expiry_ms_from_payload(payload: Optional[Dict[str, Any]]) -> Optional[int]:
+    """Extract JWT exp claim and convert to milliseconds."""
+    if not payload:
+        return None
+
+    exp = payload.get("exp")
+    if isinstance(exp, (int, float)):
+        return int(float(exp) * 1000)
+
+    return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT / "src"
+
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))

--- a/tests/fixtures/openai_codex/error_missing_instructions.json
+++ b/tests/fixtures/openai_codex/error_missing_instructions.json
@@ -1,0 +1,1 @@
+{"detail":"Instructions are required"}

--- a/tests/fixtures/openai_codex/error_stream_required.json
+++ b/tests/fixtures/openai_codex/error_stream_required.json
@@ -1,0 +1,1 @@
+{"detail":"Stream must be set to true"}

--- a/tests/fixtures/openai_codex/error_unsupported_verbosity.json
+++ b/tests/fixtures/openai_codex/error_unsupported_verbosity.json
@@ -1,0 +1,8 @@
+{
+  "error": {
+    "message": "Unsupported value: 'low' is not supported with the 'gpt-5.1-codex' model. Supported values are: 'medium'.",
+    "type": "invalid_request_error",
+    "param": "text.verbosity",
+    "code": "unsupported_value"
+  }
+}

--- a/tests/fixtures/openai_codex/protocol_notes.md
+++ b/tests/fixtures/openai_codex/protocol_notes.md
@@ -9,7 +9,7 @@ Captured against `https://chatgpt.com/backend-api/codex/responses` using a valid
 - Authorization code token exchange params:
   - `grant_type=authorization_code`
   - `client_id=app_EMoamEEZ73f0CkXaXp7hrann`
-  - `redirect_uri=http://localhost:<OPENAI_CODEX_OAUTH_PORT>/oauth2callback`
+  - `redirect_uri=http://localhost:<OPENAI_CODEX_OAUTH_PORT>/auth/callback`
   - `code_verifier=<pkce-verifier>`
 - Refresh params:
   - `grant_type=refresh_token`

--- a/tests/fixtures/openai_codex/protocol_notes.md
+++ b/tests/fixtures/openai_codex/protocol_notes.md
@@ -1,0 +1,72 @@
+# OpenAI Codex protocol capture (2026-02-12)
+
+Captured against `https://chatgpt.com/backend-api/codex/responses` using a valid Codex OAuth token from `~/.codex/auth.json`.
+
+## OAuth
+
+- Authorization endpoint: `https://auth.openai.com/oauth/authorize`
+- Token endpoint: `https://auth.openai.com/oauth/token`
+- Authorization code token exchange params:
+  - `grant_type=authorization_code`
+  - `client_id=app_EMoamEEZ73f0CkXaXp7hrann`
+  - `redirect_uri=http://localhost:<OPENAI_CODEX_OAUTH_PORT>/oauth2callback`
+  - `code_verifier=<pkce-verifier>`
+- Refresh params:
+  - `grant_type=refresh_token`
+  - `refresh_token=<token>`
+  - `client_id=app_EMoamEEZ73f0CkXaXp7hrann`
+
+## Endpoint + request shape
+
+- Endpoint: `POST /codex/responses`
+- Requires `stream=true` (non-stream returns 400 with `{"detail":"Stream must be set to true"}`)
+- Requires non-empty `instructions` (missing instructions returns 400 with `{"detail":"Instructions are required"}`)
+
+Observed working request body fields:
+
+- `model`
+- `stream` (must be `true`)
+- `store` (`false`)
+- `instructions`
+- `input` (Responses input format)
+- `text.verbosity` (for `gpt-5.1-codex`, `low` was rejected; `medium` worked)
+- `tool_choice`
+- `parallel_tool_calls`
+
+## Headers
+
+Observed and/or validated for provider implementation:
+
+- `Authorization: Bearer <access_token>`
+- `chatgpt-account-id: <account_id>`
+- `OpenAI-Beta: responses=experimental`
+- `originator: pi`
+- `Accept: text/event-stream`
+- `Content-Type: application/json`
+
+## SSE event taxonomy (observed)
+
+- `response.created`
+- `response.in_progress`
+- `response.output_item.added`
+- `response.output_item.done`
+- `response.content_part.added`
+- `response.output_text.delta`
+- `response.output_text.done`
+- `response.content_part.done`
+- `response.completed`
+
+Provider additionally supports planned aliases/events:
+
+- `response.content_part.delta`
+- `response.function_call_arguments.delta`
+- `response.function_call_arguments.done`
+- `response.incomplete`
+- `response.failed`
+- `error`
+
+## Error body fixtures
+
+- `error_missing_instructions.json`
+- `error_stream_required.json`
+- `error_unsupported_verbosity.json`

--- a/tests/fixtures/openai_codex/response_completed_event.json
+++ b/tests/fixtures/openai_codex/response_completed_event.json
@@ -1,0 +1,77 @@
+{
+  "type": "response.completed",
+  "response": {
+    "id": "id_redacted_10",
+    "object": "response",
+    "created_at": 1770926997,
+    "status": "completed",
+    "background": false,
+    "completed_at": 1770926998,
+    "error": null,
+    "frequency_penalty": 0.0,
+    "incomplete_details": null,
+    "instructions": "You are a concise assistant.",
+    "max_output_tokens": null,
+    "max_tool_calls": null,
+    "model": "gpt-5.1-codex",
+    "output": [
+      {
+        "id": "id_redacted_11",
+        "type": "reasoning",
+        "summary": []
+      },
+      {
+        "id": "id_redacted_12",
+        "type": "message",
+        "status": "completed",
+        "content": [
+          {
+            "type": "output_text",
+            "annotations": [],
+            "logprobs": [],
+            "text": "pong"
+          }
+        ],
+        "role": "assistant"
+      }
+    ],
+    "parallel_tool_calls": true,
+    "presence_penalty": 0.0,
+    "previous_response_id": null,
+    "prompt_cache_key": "prompt_cache_key_redacted_4",
+    "prompt_cache_retention": null,
+    "reasoning": {
+      "effort": "medium",
+      "summary": null
+    },
+    "safety_identifier": "safety_identifier_redacted_4",
+    "service_tier": "default",
+    "store": false,
+    "temperature": 1.0,
+    "text": {
+      "format": {
+        "type": "text"
+      },
+      "verbosity": "medium"
+    },
+    "tool_choice": "auto",
+    "tools": [],
+    "top_logprobs": 0,
+    "top_p": 1.0,
+    "truncation": "disabled",
+    "usage": {
+      "input_tokens": 21,
+      "input_tokens_details": {
+        "cached_tokens": 0
+      },
+      "output_tokens": 13,
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 34
+    },
+    "user": null,
+    "metadata": {}
+  },
+  "sequence_number": 10
+}

--- a/tests/fixtures/openai_codex/stream_content_part_delta_events.json
+++ b/tests/fixtures/openai_codex/stream_content_part_delta_events.json
@@ -1,0 +1,44 @@
+[
+  {
+    "type": "response.created",
+    "response": {
+      "id": "resp_delta_1",
+      "created_at": 1770927001,
+      "status": "in_progress"
+    }
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "msg_1",
+      "type": "message",
+      "status": "in_progress",
+      "role": "assistant"
+    }
+  },
+  {
+    "type": "response.content_part.delta",
+    "item_id": "msg_1",
+    "delta": "Hello"
+  },
+  {
+    "type": "response.content_part.delta",
+    "item_id": "msg_1",
+    "delta": " world"
+  },
+  {
+    "type": "response.incomplete",
+    "response": {
+      "id": "resp_delta_1",
+      "status": "incomplete",
+      "incomplete_details": {
+        "reason": "max_output_tokens"
+      },
+      "usage": {
+        "input_tokens": 10,
+        "output_tokens": 20,
+        "total_tokens": 30
+      }
+    }
+  }
+]

--- a/tests/fixtures/openai_codex/stream_success_events.json
+++ b/tests/fixtures/openai_codex/stream_success_events.json
@@ -1,0 +1,269 @@
+[
+  {
+    "type": "response.created",
+    "response": {
+      "id": "id_redacted_1",
+      "object": "response",
+      "created_at": 1770926997,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0.0,
+      "incomplete_details": null,
+      "instructions": "You are a concise assistant.",
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5.1-codex",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0.0,
+      "previous_response_id": null,
+      "prompt_cache_key": "prompt_cache_key_redacted_1",
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": "safety_identifier_redacted_1",
+      "service_tier": "auto",
+      "store": false,
+      "temperature": 1.0,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1.0,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 0
+  },
+  {
+    "type": "response.in_progress",
+    "response": {
+      "id": "id_redacted_2",
+      "object": "response",
+      "created_at": 1770926997,
+      "status": "in_progress",
+      "background": false,
+      "completed_at": null,
+      "error": null,
+      "frequency_penalty": 0.0,
+      "incomplete_details": null,
+      "instructions": "You are a concise assistant.",
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5.1-codex",
+      "output": [],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0.0,
+      "previous_response_id": null,
+      "prompt_cache_key": "prompt_cache_key_redacted_2",
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": "safety_identifier_redacted_2",
+      "service_tier": "auto",
+      "store": false,
+      "temperature": 1.0,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1.0,
+      "truncation": "disabled",
+      "usage": null,
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 1
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "id_redacted_3",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 2
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "id_redacted_4",
+      "type": "reasoning",
+      "summary": []
+    },
+    "output_index": 0,
+    "sequence_number": 3
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "id_redacted_5",
+      "type": "message",
+      "status": "in_progress",
+      "content": [],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 4
+  },
+  {
+    "type": "response.content_part.added",
+    "content_index": 0,
+    "item_id": "item_id_redacted_1",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": ""
+    },
+    "sequence_number": 5
+  },
+  {
+    "type": "response.output_text.delta",
+    "content_index": 0,
+    "delta": "pong",
+    "item_id": "item_id_redacted_2",
+    "logprobs": [],
+    "obfuscation": "obfuscation_redacted_1",
+    "output_index": 1,
+    "sequence_number": 6
+  },
+  {
+    "type": "response.output_text.done",
+    "content_index": 0,
+    "item_id": "item_id_redacted_3",
+    "logprobs": [],
+    "output_index": 1,
+    "sequence_number": 7,
+    "text": "pong"
+  },
+  {
+    "type": "response.content_part.done",
+    "content_index": 0,
+    "item_id": "item_id_redacted_4",
+    "output_index": 1,
+    "part": {
+      "type": "output_text",
+      "annotations": [],
+      "logprobs": [],
+      "text": "pong"
+    },
+    "sequence_number": 8
+  },
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "id": "id_redacted_6",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "pong"
+        }
+      ],
+      "role": "assistant"
+    },
+    "output_index": 1,
+    "sequence_number": 9
+  },
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "id_redacted_7",
+      "object": "response",
+      "created_at": 1770926997,
+      "status": "completed",
+      "background": false,
+      "completed_at": 1770926998,
+      "error": null,
+      "frequency_penalty": 0.0,
+      "incomplete_details": null,
+      "instructions": "You are a concise assistant.",
+      "max_output_tokens": null,
+      "max_tool_calls": null,
+      "model": "gpt-5.1-codex",
+      "output": [
+        {
+          "id": "id_redacted_8",
+          "type": "reasoning",
+          "summary": []
+        },
+        {
+          "id": "id_redacted_9",
+          "type": "message",
+          "status": "completed",
+          "content": [
+            {
+              "type": "output_text",
+              "annotations": [],
+              "logprobs": [],
+              "text": "pong"
+            }
+          ],
+          "role": "assistant"
+        }
+      ],
+      "parallel_tool_calls": true,
+      "presence_penalty": 0.0,
+      "previous_response_id": null,
+      "prompt_cache_key": "prompt_cache_key_redacted_3",
+      "prompt_cache_retention": null,
+      "reasoning": {
+        "effort": "medium",
+        "summary": null
+      },
+      "safety_identifier": "safety_identifier_redacted_3",
+      "service_tier": "default",
+      "store": false,
+      "temperature": 1.0,
+      "text": {
+        "format": {
+          "type": "text"
+        },
+        "verbosity": "medium"
+      },
+      "tool_choice": "auto",
+      "tools": [],
+      "top_logprobs": 0,
+      "top_p": 1.0,
+      "truncation": "disabled",
+      "usage": {
+        "input_tokens": 21,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 13,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 34
+      },
+      "user": null,
+      "metadata": {}
+    },
+    "sequence_number": 10
+  }
+]

--- a/tests/fixtures/openai_codex/stream_tool_call_events.json
+++ b/tests/fixtures/openai_codex/stream_tool_call_events.json
@@ -1,0 +1,50 @@
+[
+  {
+    "type": "response.created",
+    "response": {
+      "id": "resp_tool_1",
+      "created_at": 1770927000,
+      "status": "in_progress"
+    }
+  },
+  {
+    "type": "response.output_item.added",
+    "item": {
+      "id": "call_item_1",
+      "type": "function_call",
+      "call_id": "call_1",
+      "name": "get_weather",
+      "arguments": ""
+    }
+  },
+  {
+    "type": "response.function_call_arguments.delta",
+    "call_id": "call_1",
+    "delta": "{\"city\":\"San"
+  },
+  {
+    "type": "response.function_call_arguments.delta",
+    "call_id": "call_1",
+    "delta": " Francisco\"}"
+  },
+  {
+    "type": "response.function_call_arguments.done",
+    "call_id": "call_1",
+    "arguments": "{\"city\":\"San Francisco\"}"
+  },
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "resp_tool_1",
+      "status": "incomplete",
+      "incomplete_details": {
+        "reason": "tool_calls"
+      },
+      "usage": {
+        "input_tokens": 50,
+        "output_tokens": 10,
+        "total_tokens": 60
+      }
+    }
+  }
+]

--- a/tests/test_openai_codex_auth.py
+++ b/tests/test_openai_codex_auth.py
@@ -1,0 +1,178 @@
+import asyncio
+import base64
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from rotator_library.providers.openai_codex_auth_base import OpenAICodexAuthBase
+
+
+def _build_jwt(payload: dict) -> str:
+    header = {"alg": "HS256", "typ": "JWT"}
+
+    def b64url(data: dict) -> str:
+        raw = json.dumps(data, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("utf-8").rstrip("=")
+
+    return f"{b64url(header)}.{b64url(payload)}.signature"
+
+
+def test_decode_jwt_helper_valid_token():
+    auth = OpenAICodexAuthBase()
+    payload = {
+        "sub": "user-123",
+        "email": "user@example.com",
+        "exp": int(time.time()) + 3600,
+        "https://api.openai.com/auth": {"chatgpt_account_id": "acct_123"},
+    }
+    token = _build_jwt(payload)
+
+    decoded = auth._decode_jwt_unverified(token)
+    assert decoded is not None
+    assert decoded["sub"] == "user-123"
+
+
+def test_decode_jwt_helper_malformed_token():
+    auth = OpenAICodexAuthBase()
+
+    assert auth._decode_jwt_unverified("not-a-jwt") is None
+    assert auth._decode_jwt_unverified("a.b") is None
+
+
+def test_decode_jwt_helper_missing_claims_fallbacks():
+    auth = OpenAICodexAuthBase()
+
+    payload = {"sub": "fallback-sub", "exp": int(time.time()) + 300}
+    token = _build_jwt(payload)
+
+    decoded = auth._decode_jwt_unverified(token)
+    email = auth._extract_email_from_payload(decoded)
+    account_id = auth._extract_account_id_from_payload(decoded)
+
+    assert email == "fallback-sub"  # email -> sub fallback chain
+    assert account_id is None
+
+
+def test_expiry_logic_with_proactive_buffer_and_true_expiry():
+    auth = OpenAICodexAuthBase()
+
+    now_ms = int(time.time() * 1000)
+
+    # still valid (outside proactive buffer)
+    fresh = {"expiry_date": now_ms + 20 * 60 * 1000}
+    assert auth._is_token_expired(fresh) is False
+    assert auth._is_token_truly_expired(fresh) is False
+
+    # proactive refresh window (expired for refresh, still truly valid)
+    near_expiry = {"expiry_date": now_ms + 60 * 1000}
+    assert auth._is_token_expired(near_expiry) is True
+    assert auth._is_token_truly_expired(near_expiry) is False
+
+    # truly expired
+    expired = {"expiry_date": now_ms - 60 * 1000}
+    assert auth._is_token_expired(expired) is True
+    assert auth._is_token_truly_expired(expired) is True
+
+
+@pytest.mark.asyncio
+async def test_env_loading_legacy_and_numbered(monkeypatch):
+    auth = OpenAICodexAuthBase()
+
+    payload = {
+        "sub": "env-user",
+        "exp": int(time.time()) + 3600,
+        "https://api.openai.com/auth": {"chatgpt_account_id": "acct_env"},
+    }
+    access = _build_jwt(payload)
+    refresh = "rt_env"
+
+    monkeypatch.setenv("OPENAI_CODEX_ACCESS_TOKEN", access)
+    monkeypatch.setenv("OPENAI_CODEX_REFRESH_TOKEN", refresh)
+
+    # legacy load
+    legacy = auth._load_from_env("0")
+    assert legacy is not None
+    assert legacy["access_token"] == access
+    assert legacy["_proxy_metadata"]["loaded_from_env"] is True
+    assert legacy["_proxy_metadata"]["account_id"] == "acct_env"
+
+    # numbered load via env:// path
+    payload_n = {
+        "email": "numbered@example.com",
+        "exp": int(time.time()) + 3600,
+        "https://api.openai.com/auth": {"chatgpt_account_id": "acct_num"},
+    }
+    access_n = _build_jwt(payload_n)
+    monkeypatch.setenv("OPENAI_CODEX_1_ACCESS_TOKEN", access_n)
+    monkeypatch.setenv("OPENAI_CODEX_1_REFRESH_TOKEN", "rt_num")
+
+    creds = await auth._load_credentials("env://openai_codex/1")
+    assert creds["access_token"] == access_n
+    assert creds["_proxy_metadata"]["env_credential_index"] == "1"
+    assert creds["_proxy_metadata"]["account_id"] == "acct_num"
+
+
+@pytest.mark.asyncio
+async def test_save_load_round_trip_with_proxy_metadata(tmp_path: Path):
+    auth = OpenAICodexAuthBase()
+    cred_path = tmp_path / "openai_codex_oauth_1.json"
+
+    payload = {
+        "email": "roundtrip@example.com",
+        "exp": int(time.time()) + 3600,
+        "https://api.openai.com/auth": {"chatgpt_account_id": "acct_roundtrip"},
+    }
+    access = _build_jwt(payload)
+
+    creds = {
+        "access_token": access,
+        "refresh_token": "rt_roundtrip",
+        "id_token": _build_jwt(payload),
+        "expiry_date": int((time.time() + 3600) * 1000),
+        "token_uri": "https://auth.openai.com/oauth/token",
+        "_proxy_metadata": {
+            "email": "roundtrip@example.com",
+            "account_id": "acct_roundtrip",
+            "last_check_timestamp": time.time(),
+            "loaded_from_env": False,
+            "env_credential_index": None,
+        },
+    }
+
+    assert await auth._save_credentials(str(cred_path), creds) is True
+
+    # clear cache to verify disk round-trip
+    auth._credentials_cache.clear()
+    loaded = await auth._load_credentials(str(cred_path))
+
+    assert loaded["refresh_token"] == "rt_roundtrip"
+    assert loaded["_proxy_metadata"]["email"] == "roundtrip@example.com"
+    assert loaded["_proxy_metadata"]["account_id"] == "acct_roundtrip"
+
+
+@pytest.mark.asyncio
+async def test_is_credential_available_reauth_queue_and_ttl_cleanup():
+    auth = OpenAICodexAuthBase()
+    path = "/tmp/openai_codex_oauth_1.json"
+
+    # credential in active re-auth queue => unavailable
+    auth._unavailable_credentials[path] = time.time()
+    assert auth.is_credential_available(path) is False
+
+    # stale unavailable entry should auto-clean and become available
+    auth._unavailable_credentials[path] = time.time() - 999
+    auth._queued_credentials.add(path)
+    assert auth.is_credential_available(path) is True
+    assert path not in auth._unavailable_credentials
+
+    # truly expired credential should be unavailable
+    auth._credentials_cache[path] = {
+        "expiry_date": int((time.time() - 10) * 1000),
+        "_proxy_metadata": {"loaded_from_env": False},
+    }
+    assert auth.is_credential_available(path) is False
+
+    # let background queue task schedule to avoid un-awaited coroutine warnings
+    await asyncio.sleep(0)

--- a/tests/test_openai_codex_auth.py
+++ b/tests/test_openai_codex_auth.py
@@ -6,7 +6,11 @@ from pathlib import Path
 
 import pytest
 
-from rotator_library.providers.openai_codex_auth_base import OpenAICodexAuthBase
+from rotator_library.providers.openai_codex_auth_base import (
+    CALLBACK_PATH,
+    LEGACY_CALLBACK_PATH,
+    OpenAICodexAuthBase,
+)
 
 
 def _build_jwt(payload: dict) -> str:
@@ -17,6 +21,11 @@ def _build_jwt(payload: dict) -> str:
         return base64.urlsafe_b64encode(raw).decode("utf-8").rstrip("=")
 
     return f"{b64url(header)}.{b64url(payload)}.signature"
+
+
+def test_callback_paths_match_codex_oauth_client_registration():
+    assert CALLBACK_PATH == "/auth/callback"
+    assert LEGACY_CALLBACK_PATH == "/oauth2callback"
 
 
 def test_decode_jwt_helper_valid_token():

--- a/tests/test_openai_codex_import.py
+++ b/tests/test_openai_codex_import.py
@@ -1,0 +1,217 @@
+import json
+import os
+import time
+from pathlib import Path
+
+from rotator_library.credential_manager import CredentialManager
+
+
+def _build_jwt(payload: dict) -> str:
+    import base64
+
+    header = {"alg": "HS256", "typ": "JWT"}
+
+    def b64url(data: dict) -> str:
+        raw = json.dumps(data, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("utf-8").rstrip("=")
+
+    return f"{b64url(header)}.{b64url(payload)}.sig"
+
+
+def _write_codex_auth_json(path: Path):
+    payload = {
+        "email": "single@example.com",
+        "exp": int(time.time()) + 3600,
+        "https://api.openai.com/auth": {"chatgpt_account_id": "acct_single"},
+    }
+    data = {
+        "auth_mode": "oauth",
+        "OPENAI_API_KEY": None,
+        "tokens": {
+            "id_token": _build_jwt(payload),
+            "access_token": _build_jwt(payload),
+            "refresh_token": "rt_single",
+            "account_id": "acct_single",
+        },
+        "last_refresh": "2026-02-12T00:00:00Z",
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2))
+
+
+def _write_codex_accounts_json(path: Path):
+    payload_a = {
+        "email": "multi-a@example.com",
+        "exp": int(time.time()) + 3600,
+        "https://api.openai.com/auth": {"chatgpt_account_id": "acct_a"},
+    }
+    payload_b = {
+        "email": "multi-b@example.com",
+        "exp": int(time.time()) + 7200,
+        "https://api.openai.com/auth": {"chatgpt_account_id": "acct_b"},
+    }
+
+    data = {
+        "schemaVersion": 1,
+        "activeLabel": "A",
+        "accounts": [
+            {
+                "label": "A",
+                "accountId": "acct_a",
+                "access": _build_jwt(payload_a),
+                "refresh": "rt_a",
+                "idToken": _build_jwt(payload_a),
+                "expires": int((time.time() + 3600) * 1000),
+            },
+            {
+                "label": "B",
+                "accountId": "acct_b",
+                "access": _build_jwt(payload_b),
+                "refresh": "rt_b",
+                "idToken": _build_jwt(payload_b),
+                "expires": int((time.time() + 7200) * 1000),
+            },
+        ],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2))
+
+
+def test_import_from_codex_auth_and_accounts_formats(tmp_path: Path):
+    oauth_dir = tmp_path / "oauth_creds"
+    manager = CredentialManager(env_vars={}, oauth_dir=oauth_dir)
+
+    auth_json = tmp_path / ".codex" / "auth.json"
+    accounts_json = tmp_path / ".codex-accounts.json"
+    _write_codex_auth_json(auth_json)
+    _write_codex_accounts_json(accounts_json)
+
+    imported = manager._import_openai_codex_cli_credentials(
+        auth_json_path=auth_json,
+        accounts_json_path=accounts_json,
+    )
+
+    # one from auth.json + two from accounts.json
+    assert len(imported) == 3
+
+    imported_files = sorted(oauth_dir.glob("openai_codex_oauth_*.json"))
+    assert len(imported_files) == 3
+
+    payload = json.loads(imported_files[0].read_text())
+    assert payload["refresh_token"].startswith("rt_")
+    assert "_proxy_metadata" in payload
+    assert payload["_proxy_metadata"].get("account_id")
+
+
+def test_explicit_openai_codex_oauth_path_auth_json_is_normalized(tmp_path: Path):
+    oauth_dir = tmp_path / "oauth_creds"
+
+    auth_json = tmp_path / ".codex" / "auth.json"
+    _write_codex_auth_json(auth_json)
+
+    manager = CredentialManager(
+        env_vars={"OPENAI_CODEX_OAUTH_1": str(auth_json)},
+        oauth_dir=oauth_dir,
+    )
+    discovered = manager.discover_and_prepare()
+
+    assert "openai_codex" in discovered
+    assert len(discovered["openai_codex"]) == 1
+
+    imported_file = oauth_dir / "openai_codex_oauth_1.json"
+    payload = json.loads(imported_file.read_text())
+
+    # normalized proxy schema at root level (not nested under "tokens")
+    assert "tokens" not in payload
+    assert isinstance(payload.get("access_token"), str)
+    assert isinstance(payload.get("refresh_token"), str)
+    assert payload.get("token_uri") == "https://auth.openai.com/oauth/token"
+    assert "_proxy_metadata" in payload
+
+
+def test_skip_import_when_env_openai_codex_credentials_exist(tmp_path: Path):
+    oauth_dir = tmp_path / "oauth_creds"
+    manager = CredentialManager(
+        env_vars={
+            "OPENAI_CODEX_ACCESS_TOKEN": "env_access",
+            "OPENAI_CODEX_REFRESH_TOKEN": "env_refresh",
+        },
+        oauth_dir=oauth_dir,
+    )
+
+    discovered = manager.discover_and_prepare()
+
+    assert discovered["openai_codex"] == ["env://openai_codex/0"]
+    assert list(oauth_dir.glob("openai_codex_oauth_*.json")) == []
+
+
+def test_skip_import_when_local_openai_codex_credentials_exist(tmp_path: Path):
+    oauth_dir = tmp_path / "oauth_creds"
+    oauth_dir.mkdir(parents=True, exist_ok=True)
+
+    existing = oauth_dir / "openai_codex_oauth_1.json"
+    existing.write_text(
+        json.dumps(
+            {
+                "access_token": "existing",
+                "refresh_token": "existing_rt",
+                "expiry_date": int((time.time() + 3600) * 1000),
+                "token_uri": "https://auth.openai.com/oauth/token",
+                "_proxy_metadata": {
+                    "email": "existing@example.com",
+                    "account_id": "acct_existing",
+                    "last_check_timestamp": time.time(),
+                    "loaded_from_env": False,
+                    "env_credential_index": None,
+                },
+            },
+            indent=2,
+        )
+    )
+
+    manager = CredentialManager(env_vars={}, oauth_dir=oauth_dir)
+    discovered = manager.discover_and_prepare()
+
+    assert "openai_codex" in discovered
+    assert discovered["openai_codex"] == [str(existing.resolve())]
+
+
+def test_malformed_codex_source_files_are_handled_gracefully(tmp_path: Path):
+    oauth_dir = tmp_path / "oauth_creds"
+    manager = CredentialManager(env_vars={}, oauth_dir=oauth_dir)
+
+    auth_json = tmp_path / ".codex" / "auth.json"
+    accounts_json = tmp_path / ".codex-accounts.json"
+    auth_json.parent.mkdir(parents=True, exist_ok=True)
+
+    auth_json.write_text("{not valid json")
+    accounts_json.write_text(json.dumps({"schemaVersion": 1, "accounts": ["bad-entry"]}))
+
+    imported = manager._import_openai_codex_cli_credentials(
+        auth_json_path=auth_json,
+        accounts_json_path=accounts_json,
+    )
+
+    assert imported == []
+    assert list(oauth_dir.glob("openai_codex_oauth_*.json")) == []
+
+
+def test_codex_source_files_never_modified_during_import(tmp_path: Path):
+    oauth_dir = tmp_path / "oauth_creds"
+    manager = CredentialManager(env_vars={}, oauth_dir=oauth_dir)
+
+    auth_json = tmp_path / ".codex" / "auth.json"
+    accounts_json = tmp_path / ".codex-accounts.json"
+    _write_codex_auth_json(auth_json)
+    _write_codex_accounts_json(accounts_json)
+
+    auth_before = auth_json.read_text()
+    accounts_before = accounts_json.read_text()
+
+    manager._import_openai_codex_cli_credentials(
+        auth_json_path=auth_json,
+        accounts_json_path=accounts_json,
+    )
+
+    assert auth_json.read_text() == auth_before
+    assert accounts_json.read_text() == accounts_before

--- a/tests/test_openai_codex_provider.py
+++ b/tests/test_openai_codex_provider.py
@@ -1,0 +1,262 @@
+import base64
+import json
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from rotator_library.providers.openai_codex_provider import OpenAICodexProvider
+
+
+def _build_jwt(payload: dict) -> str:
+    header = {"alg": "HS256", "typ": "JWT"}
+
+    def b64url(data: dict) -> str:
+        raw = json.dumps(data, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("utf-8").rstrip("=")
+
+    return f"{b64url(header)}.{b64url(payload)}.sig"
+
+
+def _build_sse_payload(text: str = "pong") -> bytes:
+    events = [
+        {
+            "type": "response.created",
+            "response": {"id": "resp_1", "created_at": int(time.time()), "status": "in_progress"},
+        },
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "id": "msg_1",
+                "type": "message",
+                "status": "in_progress",
+                "content": [],
+                "role": "assistant",
+            },
+        },
+        {
+            "type": "response.content_part.added",
+            "item_id": "msg_1",
+            "part": {"type": "output_text", "text": ""},
+        },
+        {
+            "type": "response.output_text.delta",
+            "item_id": "msg_1",
+            "delta": text,
+        },
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_1",
+                "status": "completed",
+                "usage": {
+                    "input_tokens": 5,
+                    "output_tokens": 3,
+                    "total_tokens": 8,
+                },
+            },
+        },
+    ]
+
+    sse = "\n\n".join(f"data: {json.dumps(evt)}" for evt in events) + "\n\n"
+    return sse.encode("utf-8")
+
+
+@pytest.fixture
+def provider() -> OpenAICodexProvider:
+    return OpenAICodexProvider()
+
+
+@pytest.fixture
+def credential_file(tmp_path: Path) -> Path:
+    payload = {
+        "email": "provider@example.com",
+        "exp": int(time.time()) + 3600,
+        "https://api.openai.com/auth": {"chatgpt_account_id": "acct_provider"},
+    }
+
+    cred_path = tmp_path / "openai_codex_oauth_1.json"
+    cred_path.write_text(
+        json.dumps(
+            {
+                "access_token": _build_jwt(payload),
+                "refresh_token": "rt_provider",
+                "id_token": _build_jwt(payload),
+                "expiry_date": int((time.time() + 3600) * 1000),
+                "token_uri": "https://auth.openai.com/oauth/token",
+                "_proxy_metadata": {
+                    "email": "provider@example.com",
+                    "account_id": "acct_provider",
+                    "last_check_timestamp": time.time(),
+                    "loaded_from_env": False,
+                    "env_credential_index": None,
+                },
+            },
+            indent=2,
+        )
+    )
+    return cred_path
+
+
+def test_chat_request_mapping_to_codex_payload(provider: OpenAICodexProvider):
+    payload = provider._build_codex_payload(
+        model_name="gpt-5.1-codex",
+        messages=[
+            {"role": "system", "content": "System guidance"},
+            {"role": "user", "content": "hello"},
+        ],
+        temperature=0.2,
+        top_p=0.9,
+        max_tokens=123,
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "description": "Lookup data",
+                    "parameters": {"type": "object", "properties": {"q": {"type": "string"}}},
+                },
+            }
+        ],
+        tool_choice="auto",
+    )
+
+    assert payload["model"] == "gpt-5.1-codex"
+    assert payload["stream"] is True
+    assert payload["store"] is False
+    assert payload["instructions"] == "System guidance"
+    assert payload["input"][0]["role"] == "user"
+    assert payload["temperature"] == 0.2
+    assert payload["top_p"] == 0.9
+    assert payload["max_output_tokens"] == 123
+    assert payload["tool_choice"] == "auto"
+    assert payload["tools"][0]["name"] == "lookup"
+
+
+@pytest.mark.asyncio
+async def test_non_stream_response_mapping_and_header_construction(
+    provider: OpenAICodexProvider,
+    credential_file: Path,
+):
+    endpoint = "https://chatgpt.com/backend-api/codex/responses"
+
+    with respx.mock(assert_all_called=True) as mock_router:
+        route = mock_router.post(endpoint)
+
+        def responder(request: httpx.Request) -> httpx.Response:
+            assert request.headers.get("authorization", "").startswith("Bearer ")
+            assert request.headers.get("chatgpt-account-id") == "acct_provider"
+            assert request.headers.get("openai-beta") == "responses=experimental"
+            assert request.headers.get("originator") == "pi"
+
+            body = json.loads(request.content.decode("utf-8"))
+            assert body["stream"] is True
+            assert "instructions" in body
+            assert "input" in body
+
+            return httpx.Response(
+                status_code=200,
+                content=_build_sse_payload("pong"),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        route.mock(side_effect=responder)
+
+        async with httpx.AsyncClient() as client:
+            response = await provider.acompletion(
+                client,
+                model="openai_codex/gpt-5.1-codex",
+                messages=[{"role": "user", "content": "say pong"}],
+                stream=False,
+                credential_identifier=str(credential_file),
+            )
+
+    assert response.choices[0]["message"]["content"] == "pong"
+    assert response.usage["prompt_tokens"] == 5
+    assert response.usage["completion_tokens"] == 3
+
+
+@pytest.mark.asyncio
+async def test_env_credential_identifier_supported(monkeypatch):
+    provider = OpenAICodexProvider()
+
+    payload = {
+        "email": "env-provider@example.com",
+        "exp": int(time.time()) + 3600,
+        "https://api.openai.com/auth": {"chatgpt_account_id": "acct_env_provider"},
+    }
+
+    monkeypatch.setenv("OPENAI_CODEX_1_ACCESS_TOKEN", _build_jwt(payload))
+    monkeypatch.setenv("OPENAI_CODEX_1_REFRESH_TOKEN", "rt_env_provider")
+
+    endpoint = "https://chatgpt.com/backend-api/codex/responses"
+
+    with respx.mock(assert_all_called=True) as mock_router:
+        route = mock_router.post(endpoint)
+
+        def responder(request: httpx.Request) -> httpx.Response:
+            assert request.headers.get("chatgpt-account-id") == "acct_env_provider"
+            return httpx.Response(
+                status_code=200,
+                content=_build_sse_payload("env-ok"),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        route.mock(side_effect=responder)
+
+        async with httpx.AsyncClient() as client:
+            response = await provider.acompletion(
+                client,
+                model="openai_codex/gpt-5.1-codex",
+                messages=[{"role": "user", "content": "test env"}],
+                stream=False,
+                credential_identifier="env://openai_codex/1",
+            )
+
+    assert response.choices[0]["message"]["content"] == "env-ok"
+
+
+def test_parse_quota_error_from_retry_after_header(provider: OpenAICodexProvider):
+    request = httpx.Request("POST", "https://chatgpt.com/backend-api/codex/responses")
+    response = httpx.Response(
+        status_code=429,
+        request=request,
+        headers={"Retry-After": "42"},
+        text=json.dumps({"error": {"code": "rate_limit", "message": "Too many requests"}}),
+    )
+    error = httpx.HTTPStatusError("Rate limited", request=request, response=response)
+
+    parsed = provider.parse_quota_error(error)
+    assert parsed is not None
+    assert parsed["retry_after"] == 42
+    assert parsed["reason"] == "RATE_LIMIT"
+
+
+def test_parse_quota_error_from_resets_at_field(provider: OpenAICodexProvider):
+    now = int(time.time())
+    reset_ts = now + 120
+
+    request = httpx.Request("POST", "https://chatgpt.com/backend-api/codex/responses")
+    response = httpx.Response(
+        status_code=429,
+        request=request,
+        text=json.dumps(
+            {
+                "error": {
+                    "code": "usage_limit",
+                    "message": "quota exceeded",
+                    "resets_at": reset_ts,
+                }
+            }
+        ),
+    )
+    error = httpx.HTTPStatusError("Quota hit", request=request, response=response)
+
+    parsed = provider.parse_quota_error(error)
+    assert parsed is not None
+    assert parsed["reason"] == "USAGE_LIMIT"
+    assert parsed["quota_reset_timestamp"] == float(reset_ts)
+    assert isinstance(parsed["retry_after"], int)
+    assert parsed["retry_after"] >= 1

--- a/tests/test_openai_codex_sse.py
+++ b/tests/test_openai_codex_sse.py
@@ -1,0 +1,110 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from rotator_library.providers.openai_codex_provider import (
+    CodexSSETranslator,
+    CodexStreamError,
+)
+
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "openai_codex"
+
+
+def _load_events(name: str):
+    return json.loads((FIXTURES_DIR / name).read_text())
+
+
+def test_fixture_driven_event_sequence_to_expected_chunks():
+    events = _load_events("stream_success_events.json")
+    translator = CodexSSETranslator(model_id="openai_codex/gpt-5.1-codex")
+
+    chunks = []
+    for event in events:
+        chunks.extend(translator.process_event(event))
+
+    # content delta chunk present
+    content_chunks = [
+        c for c in chunks if c["choices"][0]["delta"].get("content")
+    ]
+    assert content_chunks
+    assert content_chunks[-1]["choices"][0]["delta"]["content"] == "pong"
+
+    # terminal chunk contains usage mapping
+    final_chunk = chunks[-1]
+    assert final_chunk["choices"][0]["finish_reason"] == "stop"
+    assert final_chunk["usage"]["prompt_tokens"] == 21
+    assert final_chunk["usage"]["completion_tokens"] == 13
+    assert final_chunk["usage"]["total_tokens"] == 34
+
+
+def test_tool_call_deltas_and_finish_reason_mapping():
+    events = _load_events("stream_tool_call_events.json")
+    translator = CodexSSETranslator(model_id="openai_codex/gpt-5.1-codex")
+
+    chunks = []
+    for event in events:
+        chunks.extend(translator.process_event(event))
+
+    tool_chunks = [
+        c for c in chunks if c["choices"][0]["delta"].get("tool_calls")
+    ]
+    assert tool_chunks
+
+    # Validate streaming argument assembly appears in deltas
+    all_args = "".join(
+        tc["function"]["arguments"]
+        for chunk in tool_chunks
+        for tc in chunk["choices"][0]["delta"]["tool_calls"]
+    )
+    assert "San" in all_args
+    assert "Francisco" in all_args
+
+    final_chunk = chunks[-1]
+    assert final_chunk["choices"][0]["finish_reason"] == "tool_calls"
+    assert final_chunk["usage"]["total_tokens"] == 60
+
+
+def test_content_part_delta_alias_and_length_finish_reason():
+    events = _load_events("stream_content_part_delta_events.json")
+    translator = CodexSSETranslator(model_id="openai_codex/gpt-5.1-codex")
+
+    chunks = []
+    for event in events:
+        chunks.extend(translator.process_event(event))
+
+    text = "".join(
+        c["choices"][0]["delta"].get("content", "")
+        for c in chunks
+    )
+    assert text == "Hello world"
+
+    final_chunk = chunks[-1]
+    assert final_chunk["choices"][0]["finish_reason"] == "length"
+    assert final_chunk["usage"]["total_tokens"] == 30
+
+
+def test_error_event_propagation():
+    translator = CodexSSETranslator(model_id="openai_codex/gpt-5.1-codex")
+
+    with pytest.raises(CodexStreamError) as exc:
+        translator.process_event(
+            {
+                "type": "error",
+                "error": {
+                    "code": "usage_limit_reached",
+                    "message": "quota reached",
+                    "type": "rate_limit_error",
+                },
+            }
+        )
+
+    assert exc.value.status_code == 429
+    assert "quota" in str(exc.value).lower()
+
+
+def test_unknown_event_tolerance():
+    translator = CodexSSETranslator(model_id="openai_codex/gpt-5.1-codex")
+    chunks = translator.process_event({"type": "response.some_unknown_event"})
+    assert chunks == []

--- a/tests/test_openai_codex_wiring.py
+++ b/tests/test_openai_codex_wiring.py
@@ -1,0 +1,26 @@
+from rotator_library.credential_manager import CredentialManager
+from rotator_library.provider_factory import get_provider_auth_class
+from rotator_library.providers import PROVIDER_PLUGINS
+from rotator_library.providers.openai_codex_auth_base import OpenAICodexAuthBase
+
+
+def test_credential_discovery_recognizes_openai_codex_env_vars(tmp_path):
+    env_vars = {
+        "OPENAI_CODEX_1_ACCESS_TOKEN": "access-1",
+        "OPENAI_CODEX_1_REFRESH_TOKEN": "refresh-1",
+    }
+
+    manager = CredentialManager(env_vars=env_vars, oauth_dir=tmp_path / "oauth_creds")
+    discovered = manager.discover_and_prepare()
+
+    assert "openai_codex" in discovered
+    assert discovered["openai_codex"] == ["env://openai_codex/1"]
+
+
+def test_provider_factory_returns_openai_codex_auth_base():
+    auth_class = get_provider_auth_class("openai_codex")
+    assert auth_class is OpenAICodexAuthBase
+
+
+def test_provider_auto_registration_includes_openai_codex():
+    assert "openai_codex" in PROVIDER_PLUGINS


### PR DESCRIPTION
## Description
adds codex oauth multi-account support

Re-targeted from #137 (was against `main`, now against `dev`).

## Testing Done
<img width="1236" height="1054" alt="image" src="https://github.com/user-attachments/assets/3917e00e-eece-461d-9bc3-cb1022961f3a" />
<img width="1417" height="582" alt="image" src="https://github.com/user-attachments/assets/1ed297f0-7e37-4762-954e-269d1e7334de" />


## Checklist
- [X] I have tested these changes locally
- [ ] I have added license headers to new files (LGPL for library, MIT for proxy)
- [ ] I have updated documentation (README/DOCUMENTATION.md) if needed
- [ ] Related issue: #

### Follow-up pushed (c3e244d)
Addressed review notes:
- clarified that the Codex OAuth client ID is public (code + docs)
- removed fire-and-forget reauth queueing in refresh failures (now awaited/tracked)
- extracted shared Codex JWT helpers and reused them in auth + import paths
- tightened quota parsing to avoid false positives from generic "quota" wording
- refactored duplicate dedupe logic and added focused tests

Ran `pytest -q` (35 passed).
