### PR TITLE
feat(gemini_cli): add Gemini 3.1 support

### DIFF
--- a/src/rotator_library/providers/gemini_cli_provider.py
+++ b/src/rotator_library/providers/gemini_cli_provider.py
@@ -66,6 +66,7 @@ AVAILABLE_MODELS = [
     "gemini-2.5-flash",
     "gemini-2.5-flash-lite",
     "gemini-3-pro-preview",
+    "gemini-3.1-pro-preview",
     "gemini-3-flash-preview",
 ]
 
@@ -456,9 +457,9 @@ class GeminiCliProvider(
     # =========================================================================
 
     def _is_gemini_3(self, model: str) -> bool:
-        """Check if model is Gemini 3 (requires special handling)."""
+        """Check if model is Gemini 3 family (3.0/3.1+, requires special handling)."""
         model_name = model.split("/")[-1].replace(":thinking", "")
-        return model_name.startswith("gemini-3-")
+        return model_name.startswith("gemini-3-") or model_name.startswith("gemini-3.")
 
     def _generate_user_prompt_id(self) -> str:
         """

--- a/src/rotator_library/providers/utilities/gemini_cli_quota_tracker.py
+++ b/src/rotator_library/providers/utilities/gemini_cli_quota_tracker.py
@@ -60,6 +60,7 @@ DEFAULT_MAX_REQUESTS: Dict[str, Dict[str, int]] = {
         # Pro group (verified: 0.4% per request = 250 requests)
         "gemini-2.5-pro": 250,
         "gemini-3-pro-preview": 250,
+        "gemini-3.1-pro-preview": 250,
         # Flash group - 2.5 (verified: ~0.0667% per request = 1500 requests)
         # gemini-2.0-flash shares quota with 2.5-flash models
         "gemini-2.0-flash": 1500,
@@ -72,6 +73,7 @@ DEFAULT_MAX_REQUESTS: Dict[str, Dict[str, int]] = {
         # Pro group (verified: 1.0% per request = 100 requests)
         "gemini-2.5-pro": 100,
         "gemini-3-pro-preview": 100,
+        "gemini-3.1-pro-preview": 100,
         # Flash group - 2.5 (verified: 0.1% per request = 1000 requests)
         "gemini-2.0-flash": 1000,
         "gemini-2.5-flash": 1000,


### PR DESCRIPTION
## Summary
- Added Gemini CLI support for `gemini-3.1-pro-preview`.
- Kept Gemini 3.1 behavior aligned with existing Gemini 3 handling (tooling + reasoning path).
- Added default quota mappings so usage estimation and quota reporting stay consistent.

## Changes
- **Gemini CLI provider (`gemini_cli_provider.py`)**
  - Added `gemini-3.1-pro-preview` to `AVAILABLE_MODELS`.
  - Added `gemini-3.1-pro-preview` to `model_quota_groups["pro"]`.
  - Extended `_is_gemini_3()` to recognize dot-version Gemini 3 family models (e.g. `gemini-3.1-*`).
- **Gemini CLI quota tracker (`gemini_cli_quota_tracker.py`)**
  - Added default `PRO` max-requests entry for `gemini-3.1-pro-preview`.
  - Added default `FREE` max-requests entry for `gemini-3.1-pro-preview`.

## Files Changed
| File | Type | Impact |
| ---- | ---- | ------ |
| `src/rotator_library/providers/gemini_cli_provider.py` | Modified | Added Gemini 3.1 model registration, pro quota-group inclusion, and 3.1-aware Gemini 3 family detection |
| `src/rotator_library/providers/utilities/gemini_cli_quota_tracker.py` | Modified | Added default quota mappings for Gemini 3.1 Pro Preview in `PRO` and `FREE` tiers |

## Testing Done
- `python -m py_compile src/rotator_library/providers/gemini_cli_provider.py src/rotator_library/providers/utilities/gemini_cli_quota_tracker.py`
- `python -m compileall src/rotator_library`
- OAuth smoke check with local credential (`oauth_creds/gemini_cli_oauth_2.json`) confirmed model list includes:
  - `gemini_cli/gemini-3.1-pro-preview`
  
## Screenshot
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f4429700-3797-423e-b644-06419a7282c6" />

## Checklist
- [x] I have tested these changes locally
- [x] I have added license headers to new files (LGPL for library, MIT for proxy) (N/A - no new files)
- [ ] I have updated documentation (README/DOCUMENTATION.md) if needed (not needed for this additive provider model update)
- [ ] Related issue: #
