### PR TITLE
feat(qwen): add coder-model (Qwen 3.5 Plus) to hardcoded models

### DIFF
--- a/src/rotator_library/providers/qwen_code_provider.py
+++ b/src/rotator_library/providers/qwen_code_provider.py
@@ -24,7 +24,11 @@ from datetime import datetime
 lib_logger = logging.getLogger("rotator_library")
 
 
-HARDCODED_MODELS = ["qwen3-coder-plus", "qwen3-coder-flash"]
+# Hardcoded model IDs for Qwen Code provider
+# - qwen3-coder-plus: Qwen3 Coder Plus
+# - qwen3-coder-flash: Qwen3 Coder Flash
+# - coder-model: Qwen 3.5 Plus (efficient hybrid model with leading coding performance)
+HARDCODED_MODELS = ["qwen3-coder-plus", "qwen3-coder-flash", "coder-model"]
 
 # OpenAI-compatible parameters supported by Qwen Code API
 SUPPORTED_PARAMS = {


### PR DESCRIPTION
Add `coder-model` (Qwen 3.5 Plus) to the hardcoded Qwen Code models list. Currently running in production and tested.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `coder-model` (Qwen 3.5 Plus) to `HARDCODED_MODELS` in `qwen_code_provider.py`.
> 
>   - **Behavior**:
>     - Add `coder-model` (Qwen 3.5 Plus) to `HARDCODED_MODELS` in `qwen_code_provider.py`.
>     - This model is now available as a fallback option if not specified in environment variables.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Mirrowel%2FLLM-API-Key-Proxy&utm_source=github&utm_medium=referral)<sup> for 87e484ef2178a897a6f502d0d6b3758cf0f09bd0. You can [customize](https://app.ellipsis.dev/Mirrowel/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->